### PR TITLE
handle pull requests in multi-project repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,7 +846,6 @@ dependencies = [
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1107,14 +1106,6 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1725,7 +1716,6 @@ dependencies = [
 "checksum security-framework 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
 "checksum security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
-"checksum serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -7,12 +7,15 @@ pub const ISSUE_NO_PROJECT_CORE_PING_PERIOD: u64 = 3600 * 8;
 pub const ISSUE_NO_PROJECT_NON_CORE_PING_PERIOD: u64 = 60 * 15;
 pub const ISSUE_NO_PROJECT_ACTION_AFTER_NPINGS: u64 = 9;
 pub const ISSUE_UNCONFIRMED_PROJECT_PING_PERIOD: u64 = 3600 * 8;
+pub const MIN_REVIEWERS: usize = 2;
 
 pub const FALLBACK_ROOM_ID: &str = "!aenJixaHcSKbJOWxYk:matrix.parity.io";
 pub const PROJECT_BACKLOG_COLUMN_NAME: &str = "backlog";
 
 pub const ISSUE_MUST_EXIST_MESSAGE: &str =
 	"Every pull request must address an issue.";
+pub const ISSUE_MUST_BE_VALID_MESSAGE: &str =
+	"Every pull request must address a valid issue; every issue in a multi-project repository must be attached to a project.";
 pub const ISSUE_NO_PROJECT_MESSAGE: &str =
 	"{1} needs to be attached to a project or it will be closed.";
 pub const ISSUE_ASSIGNEE_NOTIFICATION: &str = "{1} addressing {2} has been opened by {3}. Please reassign the issue or close the pull request.";
@@ -21,9 +24,7 @@ pub const ISSUE_REVERT_PROJECT_NOTIFICATION: &str = "The change you made to {1} 
 
 pub const REQUESTING_REVIEWS_MESSAGE: &str = "{1} is in need of reviewers.";
 pub const STATUS_FAILURE_NOTIFICATION: &str = "{1} has failed status checks.";
-pub const REQUEST_DELEGATED_REVIEW_MESSAGE: &str = "{1} needs your review in the next 72 hours, as you are the delegated reviewer.";
-pub const REQUEST_OWNER_REVIEW_MESSAGE: &str =
-	"{1} needs your review in the next 72 hours, as you are the project owner.";
+pub const REQUEST_DELEGATED_REVIEW_MESSAGE: &str = "{1} needs your review in the next 72 hours, as you are the owner or delegated reviewer.";
 
 pub const CORE_SORTING_REPO: &str = "core-sorting";
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -241,6 +241,12 @@ pub struct Review {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RequestedReviewers {
+	pub users: Vec<User>,
+	pub teams: Vec<Team>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Issue {
 	pub id: Option<i64>,
 	pub node_id: Option<String>,

--- a/src/github_bot.rs
+++ b/src/github_bot.rs
@@ -64,8 +64,18 @@ impl GithubBot {
 		pull_request: &github::PullRequest,
 	) -> Result<Vec<github::Review>> {
 		let url = pull_request.html_url.as_ref().context(error::MissingData)?;
-
 		self.client.get_all(format!("{}/reviews", url)).await
+	}
+
+	/// Returns all review requests associated with a pull request.
+	pub async fn requested_reviewers(
+		&self,
+		pull_request: &github::PullRequest,
+	) -> Result<github::RequestedReviewers> {
+		let url = pull_request.html_url.as_ref().context(error::MissingData)?;
+		self.client
+			.get(format!("{}/requested_reviewers", url))
+			.await
 	}
 
 	/// Requests a review from a user.

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -215,7 +215,7 @@ fn author_non_special_project_state_none(
 					&format!("{}", project_column.id),
 				),
 		)?;
-	} else if let Some(_owner) = &project_info.owner {
+	} else if let Some(_owner) = &project_info.owner_or_delegate() {
 		// TODO notify project owner
 	} else {
 		// TODO notify default matrix room
@@ -268,7 +268,7 @@ async fn author_non_special_project_state_unconfirmed(
 						&format!("{}", project_column.id),
 					),
 			)?;
-		} else if let Some(_owner) = &project_info.owner {
+		} else if let Some(_owner) = &project_info.owner_or_delegate() {
 			// TODO notify project owner
 		} else {
 			// TODO notify default matrix room
@@ -360,7 +360,7 @@ async fn author_non_special_project_state_denied(
 						&format!("{}", project_column.id),
 					),
 			)?;
-		} else if let Some(_owner) = &project_info.owner {
+		} else if let Some(_owner) = &project_info.owner_or_delegate() {
 			// TODO notify project owner
 		} else {
 			// TODO notify default matrix room
@@ -392,7 +392,7 @@ async fn author_non_special_project_state_denied(
 			&matrix_id,
 			&ISSUE_REVERT_PROJECT_NOTIFICATION.replace("{1}", &issue_html_url),
 		)?;
-	} else if let Some(_owner) = &project_info.owner {
+	} else if let Some(_owner) = &project_info.owner_or_delegate() {
 		// TODO notify project owner
 	} else {
 		// TODO notify default matrix room
@@ -456,7 +456,7 @@ fn author_non_special_project_state_confirmed(
 						&format!("{}", project_column.id),
 					),
 			)?;
-		} else if let Some(_owner) = &project_info.owner {
+		} else if let Some(_owner) = &project_info.owner_or_delegate() {
 			// TODO notify project owner
 		} else {
 			// TODO notify default matrix room

--- a/src/project_info.rs
+++ b/src/project_info.rs
@@ -2,28 +2,36 @@ pub type ProjectInfoMap = std::collections::HashMap<String, ProjectInfo>;
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct ProjectInfo {
-	pub owner: Option<String>,
-	pub delegated_reviewer: Option<String>,
+	owner: Option<String>,
+	delegated_reviewer: Option<String>,
 	pub whitelist: Option<Vec<String>>,
 	pub matrix_room_id: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct AuthorInfo {
-	pub is_owner: bool,
-	pub is_delegated_reviewer: bool,
+	pub is_owner_or_delegate: bool,
 	pub is_whitelisted: bool,
 }
 
+impl AuthorInfo {
+	pub fn is_special(&self) -> bool {
+		self.is_owner_or_delegate || self.is_whitelisted
+	}
+}
+
 impl ProjectInfo {
+	pub fn owner_or_delegate(&self) -> Option<&String> {
+		self.delegated_reviewer.as_ref().or(self.owner.as_ref())
+	}
+
 	pub fn author_info(&self, login: &str) -> AuthorInfo {
 		let is_owner = self.is_owner(login);
 		let is_delegated_reviewer = self.is_delegated_reviewer(login);
 		let is_whitelisted = self.is_whitelisted(login);
 
 		AuthorInfo {
-			is_owner,
-			is_delegated_reviewer,
+			is_owner_or_delegate: is_owner || is_delegated_reviewer,
 			is_whitelisted,
 		}
 	}


### PR DESCRIPTION

- Fixes #18  
- check existing review-requests before requesting reviews
- replace `AuthorInfo`'s `owner` and `delgated_reviewer` with `owner_or_delegate`, since the `delegate` should act as a temporary stand-in for the `owner`