### PR TITLE
Enable separate configuration for staging

### DIFF
--- a/kubernetes/processbot/templates/processbot.yaml
+++ b/kubernetes/processbot/templates/processbot.yaml
@@ -136,7 +136,7 @@ spec:
             - name: GITLAB_HOSTNAME
               value: gitlab.parity.io
             - name: GITLAB_PROJECT
-              value: parity/polkadot
+              value: {{ .Values.processbot.config.GITLAB_PROJECT }}
             - name: GITLAB_JOB_NAME
               value: build-linux-release-pr
 

--- a/kubernetes/processbot/templates/processbot.yaml
+++ b/kubernetes/processbot/templates/processbot.yaml
@@ -86,7 +86,7 @@ spec:
             - name: WEBHOOK_PORT
               value: {{ quote .Values.processbot.config.WEBHOOK_PORT }}
             - name: GITHUB_APP_ID
-              value: "51719"
+              value: {{ quote .Values.processbot.config.GITHUB_APP_ID }}
             - name: DB_PATH
               value: /usr/local/share/db
             - name: BAMBOO_TICK_SECS
@@ -94,7 +94,7 @@ spec:
             - name: MATRIX_SILENT
               value: "false"
             - name: MATRIX_DEFAULT_CHANNEL_ID
-              value: "!ZXvnxSiXstTeRmkMGk:matrix.parity.io" 
+              value: "!ZXvnxSiXstTeRmkMGk:matrix.parity.io"
             - name: MAIN_TICK_SECS
               value: "300"
             - name: MATRIX_HOMESERVER
@@ -126,7 +126,7 @@ spec:
             - name: MIN_REVIEWERS
               value: "2"
             - name: LOGS_ROOM_ID
-              value: "!ZXvnxSiXstTeRmkMGk:matrix.parity.io" 
+              value: "!ZXvnxSiXstTeRmkMGk:matrix.parity.io"
             - name: TEST_REPO_NAME
               value: test-repo
             - name: TEST_INSTALLATION_LOGIN

--- a/kubernetes/processbot/values-parity-prod.yaml
+++ b/kubernetes/processbot/values-parity-prod.yaml
@@ -1,3 +1,2 @@
-orgName: paritytech
 environment: production
 ingressDomain: processbot.parity.io

--- a/kubernetes/processbot/values-parity-prod.yaml
+++ b/kubernetes/processbot/values-parity-prod.yaml
@@ -1,2 +1,5 @@
 environment: production
 ingressDomain: processbot.parity.io
+processbot:
+  config:
+    GITHUB_APP_ID: 51719

--- a/kubernetes/processbot/values-parity-prod.yaml
+++ b/kubernetes/processbot/values-parity-prod.yaml
@@ -3,3 +3,4 @@ ingressDomain: processbot.parity.io
 processbot:
   config:
     GITHUB_APP_ID: 51719
+    GITLAB_PROJECT: parity/polkadot

--- a/kubernetes/processbot/values-staging.yaml
+++ b/kubernetes/processbot/values-staging.yaml
@@ -3,3 +3,4 @@ ingressDomain: processbot.test-installations.parity.io
 processbot:
   config:
     GITHUB_APP_ID: 81160
+    GITLAB_PROJECT: parity/polkadot-for-processbot-staging

--- a/kubernetes/processbot/values-staging.yaml
+++ b/kubernetes/processbot/values-staging.yaml
@@ -1,2 +1,5 @@
 environment: staging
 ingressDomain: processbot.test-installations.parity.io
+processbot:
+  config:
+    GITHUB_APP_ID: 81160

--- a/kubernetes/processbot/values-staging.yaml
+++ b/kubernetes/processbot/values-staging.yaml
@@ -1,3 +1,2 @@
-orgName: paritytech
 environment: staging
 ingressDomain: processbot.test-installations.parity.io

--- a/kubernetes/processbot/values.yaml
+++ b/kubernetes/processbot/values.yaml
@@ -4,7 +4,7 @@ processbot:
   config:
     KUBE_NAMESPACE: processbot
     WEBHOOK_PORT: 8080
-  secret: 
+  secret:
     PROCESSBOT_KEY: from-gitlab-vars
     BAMBOO_TOKEN: from-gitlab-vars
     MATRIX_ACCESS_TOKEN: from-gitlab-vars

--- a/kubernetes/processbot/values.yaml
+++ b/kubernetes/processbot/values.yaml
@@ -1,3 +1,4 @@
+orgName: paritytech
 dockerTag: from-gitlab-vars
 processbot:
   config:


### PR DESCRIPTION
This change reads the previously hard-coded values for `GITLAB_PROJECT` and `GITHUB_APP_ID` from `values-staging.yaml` and `values-parity-prod.yaml`, respectively. This enables using a separate Github repository with the Polkadot code and a separate Github App that has the webhook URL set to the staging deployment of processbot.
Plus one minor, unrelated cleanup change.