### PR TITLE
Remove redundant application versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "parity-processbot"
-version = "0.1.0"
 authors = ["Joseph Mark <sjeohp@gmail.com>"]
 edition = "2018"
 

--- a/kubernetes/processbot/Chart.yaml
+++ b/kubernetes/processbot/Chart.yaml
@@ -14,9 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 0.1.16
-
+version: 0.2.0


### PR DESCRIPTION
Versioning for processbot is done with git tags. Keeping the version in sync in multiple places does not work in practice.