### PR TITLE
3x8 buildah

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,7 +73,7 @@ test-build:
       --tag "$DOCKER_IMAGE:$CI_COMMIT_REF_NAME" .
     - echo "$Docker_Hub_Pass_Parity" |
         buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
-    - buildah push "$DOCKER_IMAGE:$CI_COMMIT_REF_NAME"
+    - buildah push --format=v2s2 "$DOCKER_IMAGE:$CI_COMMIT_REF_NAME"
   tags:
     - kubernetes-parity-build
       

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,20 +60,20 @@ test-build:
 #### stage:                        dockerize
 
 .build_and_push:                   &build_and_push
-  image:                           docker:git
-  services:
-    - docker:dind
+  image:                           quay.io/buildah/stable
   variables:
     GIT_STRATEGY:                  none
-    DOCKER_DRIVER:                 overlay2
-    DOCKER_HOST:                   tcp://localhost:2375
     DOCKER_IMAGE:                  "${CI_REGISTRY}/${KUBE_NAMESPACE}"
   interruptible:                   true
   script:
-    - docker login -u "$Docker_Hub_User_Parity" -p "$Docker_Hub_Pass_Parity"
     - cd ./artifacts
-    - docker build -t "$DOCKER_IMAGE:$CI_COMMIT_REF_NAME" .
-    - docker push "$DOCKER_IMAGE:$CI_COMMIT_REF_NAME"
+    - buildah bud 
+      --squash
+      --format=docker
+      --tag "$DOCKER_IMAGE:$CI_COMMIT_REF_NAME" .
+    - echo "$Docker_Hub_Pass_Parity" |
+        buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
+    - buildah push "$DOCKER_IMAGE:$CI_COMMIT_REF_NAME"
   tags:
     - kubernetes-parity-build
       


### PR DESCRIPTION
Fixes the issue with containerization.

Images manifests are changing with the transition to buildah.

For the reference paritytech/scripts#246