### PR TITLE
Implement new burn-in flow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,9 @@ dockerize-processbot:
       --set processbot.secret.BAMBOO_TOKEN=${BAMBOO_TOKEN}
       --set processbot.secret.MATRIX_ACCESS_TOKEN=${MATRIX_ACCESS_TOKEN}
       --set processbot.secret.WEBHOOK_SECRET=${WEBHOOK_SECRET}
-      --set processbot.secret.GITLAB_PRIVATE_TOKEN=${GITLAB_PRIVATE_TOKEN}
+      --set processbot.secret.BURNIN_GITLAB_TOKEN=${BURNIN_GITLAB_TOKEN}
+      --set processbot.config.BURNIN_GITLAB_HOST=${BURNIN_GITLAB_HOST}
+      --set processbot.config.BURNIN_GITLAB_PROJECT=${BURNIN_GITLAB_PROJECT}
 
 deploy-staging:
   stage:                           deploy-staging

--- a/kubernetes/processbot/templates/env-secrets.yaml
+++ b/kubernetes/processbot/templates/env-secrets.yaml
@@ -8,4 +8,4 @@ data:
   BAMBOO_TOKEN: {{ .Values.processbot.secret.BAMBOO_TOKEN }}
   MATRIX_ACCESS_TOKEN: {{ .Values.processbot.secret.MATRIX_ACCESS_TOKEN }}
   WEBHOOK_SECRET: {{ .Values.processbot.secret.WEBHOOK_SECRET }}
-  GITLAB_PRIVATE_TOKEN: {{ .Values.processbot.secret.GITLAB_PRIVATE_TOKEN }}
+  BURNIN_GITLAB_TOKEN: {{ .Values.processbot.secret.BURNIN_GITLAB_TOKEN }}

--- a/kubernetes/processbot/templates/processbot.yaml
+++ b/kubernetes/processbot/templates/processbot.yaml
@@ -70,11 +70,11 @@ spec:
                   secretKeyRef:
                       name: env-secrets
                       key: WEBHOOK_SECRET
-            - name: GITLAB_PRIVATE_TOKEN
+            - name: BURNIN_GITLAB_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: env-secrets
-                  key: GITLAB_PRIVATE_TOKEN
+                  key: BURNIN_GITLAB_TOKEN
             - name: RUST_BACKTRACE
               value: full
             - name: RUST_LOG
@@ -133,10 +133,10 @@ spec:
               value: sjeohp-test-org
             - name: ENVIRONMENT
               value: {{ .Values.environment }}
-            - name: GITLAB_HOSTNAME
-              value: gitlab.parity.io
-            - name: GITLAB_PROJECT
-              value: {{ .Values.processbot.config.GITLAB_PROJECT }}
+            - name: BURNIN_GITLAB_HOST
+              value: {{ quote .Values.processbot.config.BURNIN_GITLAB_HOST }}
+            - name: BURNIN_GITLAB_PROJECT
+              value: {{ quote .Values.processbot.config.BURNIN_GITLAB_PROJECT }}
             - name: BURNIN_ROOM_ID
               value: "!GRPGDBcewDjLUGCzAy:matrix.parity.io"
 

--- a/kubernetes/processbot/templates/processbot.yaml
+++ b/kubernetes/processbot/templates/processbot.yaml
@@ -137,8 +137,6 @@ spec:
               value: gitlab.parity.io
             - name: GITLAB_PROJECT
               value: {{ .Values.processbot.config.GITLAB_PROJECT }}
-            - name: GITLAB_JOB_NAME
-              value: build-linux-release-pr
             - name: BURNIN_ROOM_ID
               value: "!GRPGDBcewDjLUGCzAy:matrix.parity.io"
 

--- a/kubernetes/processbot/templates/processbot.yaml
+++ b/kubernetes/processbot/templates/processbot.yaml
@@ -139,6 +139,8 @@ spec:
               value: {{ .Values.processbot.config.GITLAB_PROJECT }}
             - name: GITLAB_JOB_NAME
               value: build-linux-release-pr
+            - name: BURNIN_ROOM_ID
+              value: "!GRPGDBcewDjLUGCzAy:matrix.parity.io"
 
 
 ---

--- a/kubernetes/processbot/values.yaml
+++ b/kubernetes/processbot/values.yaml
@@ -4,9 +4,11 @@ processbot:
   config:
     KUBE_NAMESPACE: processbot
     WEBHOOK_PORT: 8080
+    BURNIN_GITLAB_HOST: from-gitlab-vars
+    BURNIN_GITLAB_PROJECT: from-gitlab-vars
   secret:
     PROCESSBOT_KEY: from-gitlab-vars
     BAMBOO_TOKEN: from-gitlab-vars
     MATRIX_ACCESS_TOKEN: from-gitlab-vars
     WEBHOOK_SECRET: from-gitlab-vars
-    GITLAB_PRIVATE_TOKEN: from-gitlab-vars
+    BURNIN_GITLAB_TOKEN: from-gitlab-vars

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,8 @@ pull request author or publicly to the default channel if the author's Matrix ha
 `GITLAB_PROJECT`: Name of the project in Gitlab where CI jobs for burn-in deployments can be found.
 
 `GITLAB_PRIVATE_TOKEN`: Authentication token for the Gitlab server at GITLAB_HOSTNAME.
+
+`BURNIN_ROOM_ID`: Matrix room ID for notifications about burn-in requests
 */
 
 #[derive(Debug, Clone)]
@@ -175,6 +177,8 @@ pub struct BotConfig {
 	pub core_sorting_repo_name: String,
 	/// matrix room id for sending app logs
 	pub logs_room_id: String,
+	/// matrix room id for notifications about burn-in requests
+	pub burnin_room_id: String,
 }
 
 impl BotConfig {
@@ -261,6 +265,8 @@ impl BotConfig {
 				.expect("CORE_SORTING_REPO_NAME"),
 
 			logs_room_id: dotenv::var("LOGS_ROOM_ID").expect("LOGS_ROOM_ID"),
+			burnin_room_id: dotenv::var("BURNIN_ROOM_ID")
+				.expect("BURNIN_ROOM_ID"),
 		}
 	}
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,11 +45,11 @@ pull request author or publicly to the default channel if the author's Matrix ha
 
 `TEST_REPO_NAME`: Name of a Github repository to be used for testing.
 
-`GITLAB_HOSTNAME`: Hostname of the Gitlab server used for burn-in deployment related CI jobs.
+`BURNIN_GITLAB_HOST`: Name of the Gitlab server used for burn-in automation.
 
-`GITLAB_PROJECT`: Name of the project in Gitlab where CI jobs for burn-in deployments can be found.
+`BURNIN_GITLAB_PROJECT`: Name of the Gitlab project to which burn-in requests are submitted.
 
-`GITLAB_PRIVATE_TOKEN`: Authentication token for the Gitlab server at GITLAB_HOSTNAME.
+`BURNIN_GITLAB_TOKEN`: Authentication token for the Gitlab server at BURNIN_GITLAB_HOST.
 
 `BURNIN_ROOM_ID`: Matrix room ID for notifications about burn-in requests
 */
@@ -71,9 +71,9 @@ pub struct MainConfig {
 	pub bamboo_tick_secs: u64,
 	/// if true then matrix notifications will not be sent
 	pub matrix_silent: bool,
-	pub gitlab_hostname: String,
-	pub gitlab_project: String,
-	pub gitlab_private_token: String,
+	pub burnin_gitlab_host: String,
+	pub burnin_gitlab_project: String,
+	pub burnin_gitlab_token: String,
 }
 
 impl MainConfig {
@@ -114,12 +114,12 @@ impl MainConfig {
 		let private_key = std::fs::read(&private_key_path)
 			.expect("Couldn't find private key.");
 
-		let gitlab_hostname =
-			dotenv::var("GITLAB_HOSTNAME").expect("GITLAB_HOSTNAME");
-		let gitlab_project =
-			dotenv::var("GITLAB_PROJECT").expect("GITLAB_PROJECT");
-		let gitlab_private_token =
-			dotenv::var("GITLAB_PRIVATE_TOKEN").expect("GITLAB_PRIVATE_TOKEN");
+		let burnin_gitlab_host =
+			dotenv::var("BURNIN_GITLAB_HOST").expect("BURNIN_GITLAB_HOST");
+		let burnin_gitlab_project = dotenv::var("BURNIN_GITLAB_PROJECT")
+			.expect("BURNIN_GITLAB_PROJECT");
+		let burnin_gitlab_token =
+			dotenv::var("BURNIN_GITLAB_TOKEN").expect("BURNIN_GITLAB_TOKEN");
 
 		Self {
 			environment,
@@ -136,9 +136,9 @@ impl MainConfig {
 			main_tick_secs,
 			bamboo_tick_secs,
 			matrix_silent,
-			gitlab_hostname,
-			gitlab_project,
-			gitlab_private_token,
+			burnin_gitlab_host,
+			burnin_gitlab_project,
+			burnin_gitlab_token,
 		}
 	}
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,7 +73,6 @@ pub struct MainConfig {
 	pub matrix_silent: bool,
 	pub gitlab_hostname: String,
 	pub gitlab_project: String,
-	pub gitlab_job_name: String,
 	pub gitlab_private_token: String,
 }
 
@@ -119,8 +118,6 @@ impl MainConfig {
 			dotenv::var("GITLAB_HOSTNAME").expect("GITLAB_HOSTNAME");
 		let gitlab_project =
 			dotenv::var("GITLAB_PROJECT").expect("GITLAB_PROJECT");
-		let gitlab_job_name =
-			dotenv::var("GITLAB_JOB_NAME").expect("GITLAB_JOB_NAME");
 		let gitlab_private_token =
 			dotenv::var("GITLAB_PRIVATE_TOKEN").expect("GITLAB_PRIVATE_TOKEN");
 
@@ -141,7 +138,6 @@ impl MainConfig {
 			matrix_silent,
 			gitlab_hostname,
 			gitlab_project,
-			gitlab_job_name,
 			gitlab_private_token,
 		}
 	}

--- a/src/error.rs
+++ b/src/error.rs
@@ -183,3 +183,9 @@ impl From<curl::Error> for Error {
 		}
 	}
 }
+
+impl From<serde_json::Error> for Error {
+	fn from(value: serde_json::Error) -> Self {
+		Error::Json { source: value }
+	}
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -140,7 +140,7 @@ pub enum Error {
 		body: String,
 	},
 
-	// Gitlab API responded with an HTTP status >299 to requests other than POST /jobs/<id>/play
+	// generic error for Gitlab API requests
 	#[snafu(display(
 		"{} {} failed with HTTP status {} and body: {}",
 		method,
@@ -187,5 +187,19 @@ impl From<curl::Error> for Error {
 impl From<serde_json::Error> for Error {
 	fn from(value: serde_json::Error) -> Self {
 		Error::Json { source: value }
+	}
+}
+
+impl From<reqwest::Error> for Error {
+	fn from(value: reqwest::Error) -> Self {
+		Error::Http { source: value }
+	}
+}
+
+impl From<reqwest::header::InvalidHeaderValue> for Error {
+	fn from(_: reqwest::header::InvalidHeaderValue) -> Self {
+		Error::Message {
+			msg: String::from("invalid header value"),
+		}
 	}
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -848,6 +848,8 @@ pub enum Payload {
 		number: i64,
 		pull_request: PullRequest,
 		repository: Repository,
+		sender: User,
+		label: Label,
 	},
 	IssueComment {
 		action: IssueCommentAction,

--- a/src/github.rs
+++ b/src/github.rs
@@ -822,7 +822,7 @@ pub struct Branch {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum PullRequestAction {
 	Opened,
 	Edited,

--- a/src/gitlab_bot.rs
+++ b/src/gitlab_bot.rs
@@ -68,6 +68,25 @@ impl GitlabBot {
 		})
 	}
 
+	pub async fn create_file(
+		&self,
+		path: &str,
+		branch: &str,
+		commit_msg: &str,
+		content: &str,
+	) -> Result<()> {
+		let body = serde_json::json!({
+			"author_name": "processbot",
+			"branch": branch,
+			"commit_message": commit_msg,
+			"content": content
+		});
+
+		let url = self.urls.create_file_url(path)?;
+		self.client.post(url).json(&body).send().await?;
+		Ok(())
+	}
+
 	pub async fn build_artifact(&self, commit_sha: &str) -> Result<Job> {
 		let job = self.fetch_job(commit_sha).await?;
 

--- a/src/gitlab_bot.rs
+++ b/src/gitlab_bot.rs
@@ -299,6 +299,24 @@ impl UrlBuilder {
 
 		Ok(play_job_url)
 	}
+
+	pub fn create_file_url(&self, path: &str) -> Result<Url> {
+		let mut create_file_url = self.base_url.clone();
+
+		{
+			let mut path_segments =
+				create_file_url.path_segments_mut().or_else(|()| {
+					Err(Error::UrlCannotBeBase {
+						url: self.base_url.to_string(),
+					})
+				})?;
+
+			path_segments.extend(&self.base_path);
+			path_segments.extend(&["repository", "files", &path.to_string()]);
+		}
+
+		Ok(create_file_url)
+	}
 }
 
 #[cfg(test)]
@@ -354,6 +372,17 @@ mod tests {
 		assert_url(
 			jobs_url,
 			"https://gitlab.parity.io/api/v4/projects/parity%2Fprocessbot-test-repo/jobs/23/play"
+		);
+	}
+
+	#[test]
+	fn test_create_file_url() {
+		let cf_url =
+			builder().create_file_url("requests/request-1610469388.toml");
+
+		assert_url(
+			cf_url,
+			"https://gitlab.parity.io/api/v4/projects/parity%2Fprocessbot-test-repo/repository/files/requests%2Frequest-1610469388.toml"
 		);
 	}
 }

--- a/src/gitlab_bot.rs
+++ b/src/gitlab_bot.rs
@@ -5,7 +5,6 @@ use url::Url;
 
 pub struct GitlabBot {
 	urls: UrlBuilder,
-	ci_job_name: String,
 	client: Client,
 }
 
@@ -40,7 +39,6 @@ impl GitlabBot {
 	pub async fn new_with_token(
 		hostname: &str,
 		project: &str,
-		ci_job_name: &str,
 		private_token: &str,
 	) -> Result<Self> {
 		let urls = UrlBuilder::new(hostname, project)?;
@@ -63,7 +61,6 @@ impl GitlabBot {
 
 		Ok(Self {
 			urls,
-			ci_job_name: ci_job_name.to_owned(),
 			client: client.to_owned(),
 		})
 	}
@@ -85,95 +82,6 @@ impl GitlabBot {
 		let url = self.urls.create_file_url(path)?;
 		self.client.post(url).json(&body).send().await?;
 		Ok(())
-	}
-
-	pub async fn build_artifact(&self, commit_sha: &str) -> Result<Job> {
-		let job = self.fetch_job(commit_sha).await?;
-
-		// JobStatus is used by the caller to decide what message to post on Github/Matrix.
-		let status = match job.status.to_lowercase().trim() {
-			"manual" => JobStatus::Started,
-			"running" => JobStatus::AlreadyRunning,
-			"success" => JobStatus::Finished,
-			"failed" => JobStatus::Finished,
-			"canceled" => JobStatus::Finished,
-			_ => JobStatus::Unknown,
-		};
-
-		if status == JobStatus::Started {
-			let play_job_url = self.urls.play_job_url(job.id)?;
-			let response = self.client.post(play_job_url).send().await?;
-			let status: u32 = response.status().as_u16() as u32;
-
-			if status > 299 {
-				return Err(Error::StartingGitlabJobFailed {
-					status,
-					url: job.web_url,
-					body: response.text().await?,
-				});
-			}
-		}
-
-		Ok(Job {
-			status,
-			status_raw: job.status,
-			url: job.web_url,
-		})
-	}
-
-	async fn fetch_job(&self, commit_sha: &str) -> Result<GitlabJob> {
-		let pipeline = self.fetch_pipeline_for_commit(commit_sha).await?;
-		let jobs = self.fetch_jobs_for_pipeline(pipeline.id).await?;
-
-		for job in jobs {
-			if job.name == self.ci_job_name {
-				return Ok(job);
-			}
-		}
-
-		Err(Error::GitlabJobNotFound {
-			commit_sha: commit_sha.to_string(),
-		})
-	}
-
-	async fn fetch_jobs_for_pipeline(
-		&self,
-		pipeline_id: i64,
-	) -> Result<Vec<GitlabJob>> {
-		let jobs_url = self.urls.jobs_url_for_pipeline(pipeline_id)?;
-
-		let jobs: Vec<GitlabJob> = self
-			.client
-			.get(jobs_url)
-			.send()
-			.await?
-			.json::<Vec<GitlabJob>>()
-			.await?;
-
-		Ok(jobs)
-	}
-
-	async fn fetch_pipeline_for_commit(
-		&self,
-		commit_sha: &str,
-	) -> Result<Pipeline> {
-		let pipelines_url = self.urls.pipelines_url_for_commit(commit_sha)?;
-
-		let pipelines: Vec<Pipeline> = self
-			.client
-			.get(pipelines_url)
-			.send()
-			.await?
-			.json::<Vec<Pipeline>>()
-			.await?;
-
-		if pipelines.is_empty() {
-			return Err(Error::GitlabJobNotFound {
-				commit_sha: commit_sha.to_string(),
-			});
-		}
-
-		Ok(pipelines[0].clone())
 	}
 }
 
@@ -216,72 +124,6 @@ impl UrlBuilder {
 		Ok(project_url)
 	}
 
-	pub fn pipelines_url_for_commit(&self, commit_sha: &str) -> Result<Url> {
-		let mut pipelines_url = self.base_url.clone();
-
-		{
-			let mut path_segments =
-				pipelines_url.path_segments_mut().or_else(|()| {
-					Err(Error::UrlCannotBeBase {
-						url: self.base_url.to_string(),
-					})
-				})?;
-			path_segments.extend(&self.base_path);
-			path_segments.push("pipelines");
-		}
-
-		// If there are multiple pipelines for the same commit, assume the most recently updated
-		// one contains the job we want to trigger.
-		pipelines_url
-			.query_pairs_mut()
-			.clear()
-			.append_pair("sha", commit_sha)
-			.append_pair("order_by", "updated_at")
-			.append_pair("per_page", "1");
-
-		Ok(pipelines_url)
-	}
-
-	pub fn jobs_url_for_pipeline(&self, pipeline_id: i64) -> Result<Url> {
-		let mut jobs_url = self.base_url.clone();
-
-		{
-			let mut path_segments =
-				jobs_url.path_segments_mut().or_else(|()| {
-					Err(Error::UrlCannotBeBase {
-						url: self.base_url.to_string(),
-					})
-				})?;
-
-			path_segments.extend(&self.base_path);
-			path_segments.extend(&[
-				"pipelines",
-				&pipeline_id.to_string(),
-				"jobs",
-			]);
-		}
-
-		Ok(jobs_url)
-	}
-
-	pub fn play_job_url(&self, job_id: i64) -> Result<Url> {
-		let mut play_job_url = self.base_url.clone();
-
-		{
-			let mut path_segments =
-				play_job_url.path_segments_mut().or_else(|()| {
-					Err(Error::UrlCannotBeBase {
-						url: self.base_url.to_string(),
-					})
-				})?;
-
-			path_segments.extend(&self.base_path);
-			path_segments.extend(&["jobs", &job_id.to_string(), "play"]);
-		}
-
-		Ok(play_job_url)
-	}
-
 	pub fn create_file_url(&self, path: &str) -> Result<Url> {
 		let mut create_file_url = self.base_url.clone();
 
@@ -322,38 +164,6 @@ mod tests {
 		assert_url(
 			project_url,
 			"https://gitlab.parity.io/api/v4/projects/parity%2Fprocessbot-test-repo"
-		);
-	}
-
-	#[test]
-	fn test_pipelines_url_for_commit() {
-		let pipelines_url = builder().pipelines_url_for_commit(
-			"3194e877da3bb6e28df5c0a0d27abcf31b11ba60",
-		);
-
-		assert_url(
-			pipelines_url,
-			"https://gitlab.parity.io/api/v4/projects/parity%2Fprocessbot-test-repo/pipelines?sha=3194e877da3bb6e28df5c0a0d27abcf31b11ba60&order_by=updated_at&per_page=1"
-		);
-	}
-
-	#[test]
-	fn test_jobs_url_for_pipeline() {
-		let jobs_url = builder().jobs_url_for_pipeline(42);
-
-		assert_url(
-			jobs_url,
-			"https://gitlab.parity.io/api/v4/projects/parity%2Fprocessbot-test-repo/pipelines/42/jobs"
-		);
-	}
-
-	#[test]
-	fn test_play_jobs_url() {
-		let jobs_url = builder().play_job_url(23);
-
-		assert_url(
-			jobs_url,
-			"https://gitlab.parity.io/api/v4/projects/parity%2Fprocessbot-test-repo/jobs/23/play"
 		);
 	}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,6 @@ async fn run() -> anyhow::Result<()> {
 	let gitlab_bot = gitlab_bot::GitlabBot::new_with_token(
 		&config.gitlab_hostname,
 		&config.gitlab_project,
-		&config.gitlab_job_name,
 		&config.gitlab_private_token,
 	)
 	.await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,8 @@ async fn run() -> anyhow::Result<()> {
 		&config.gitlab_project,
 		&config.gitlab_job_name,
 		&config.gitlab_private_token,
-	)?;
+	)
+	.await?;
 
 	// the bamboo queries can take a long time so only wait for it
 	// on launch. subsequently update in the background.

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,11 +43,11 @@ async fn run() -> anyhow::Result<()> {
 	)
 	.await?;
 
-	log::info!("Connecting to Gitlab https://{}", config.gitlab_hostname);
+	log::info!("Connecting to Gitlab https://{}", config.burnin_gitlab_host);
 	let gitlab_bot = gitlab_bot::GitlabBot::new_with_token(
-		&config.gitlab_hostname,
-		&config.gitlab_project,
-		&config.gitlab_private_token,
+		&config.burnin_gitlab_host,
+		&config.burnin_gitlab_project,
+		&config.burnin_gitlab_token,
 	)
 	.await?;
 

--- a/src/matrix_bot.rs
+++ b/src/matrix_bot.rs
@@ -176,14 +176,14 @@ impl MatrixBot {
 		self.send_to_room(&self.default_channel_id, msg)
 	}
 
-	pub fn send_html_to_default(&self, msg: &str) -> Result<()> {
+	pub fn send_html_to_room(&self, room_id: &str, msg: &str) -> Result<()> {
 		if self.silent {
 			return Ok(());
 		};
 		matrix::send_html_message(
 			&self.homeserver,
 			&self.access_token,
-			&self.default_channel_id,
+			&room_id,
 			msg,
 		)
 	}

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -669,7 +669,7 @@ async fn handle_burnin_request(
 	let unexpected_error_msg = "Starting CI job for burn-in deployment failed with an unexpected error; see logs.".to_string();
 	let mut matrix_msg: Option<String> = None;
 
-	let msg = match gitlab_bot.build_artifact(&pr.head.sha) {
+	let msg = match gitlab_bot.build_artifact(&pr.head.sha).await {
 		Ok(job) => {
 			let ci_job_link = make_job_link(job.url);
 


### PR DESCRIPTION
Processbot will now react to the `A1-needsburnin` label being added with a comment that explains how to submit a burn-in request.

When such a request is received via PR comment by the developer, the included ToML content is committed to the Gitlab repository used for managing burn-in tests.

closes #240 