### PR TITLE
Add logging format for GKE

### DIFF
--- a/src/logging/gke.rs
+++ b/src/logging/gke.rs
@@ -1,0 +1,39 @@
+// GKE stands for Google Kubernetes Engine
+
+use env_logger::fmt::Formatter;
+use log::Record;
+use serde::Serialize;
+use std::io::{self, Write};
+
+#[derive(Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+enum Severity {
+	Error,
+	Info,
+}
+
+#[derive(Serialize)]
+struct Log {
+	pub severity: Severity,
+	pub message: String,
+	pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+pub fn format(fmt: &mut Formatter, record: &Record) -> io::Result<()> {
+	writeln!(
+		fmt,
+		"{}",
+		serde_json::to_string(&Log {
+			severity: match record.level() {
+				log::Level::Error => Severity::Error,
+				_ => Severity::Info,
+			},
+			message: format!("{}", record.args()),
+			timestamp: chrono::Utc::now(),
+		})
+		.unwrap_or_else(|_| format!(
+			"ERROR: Unable to serialize {}",
+			record.args()
+		))
+	)
+}

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -1,0 +1,1 @@
+pub mod gke;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use rocksdb::DB;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use tokio::sync::Mutex;
+mod logging;
 
 use parity_processbot::{
 	config::{BotConfig, MainConfig},
@@ -21,6 +22,7 @@ async fn main() -> std::io::Result<()> {
 async fn run() -> anyhow::Result<()> {
 	let config = MainConfig::from_env();
 	env_logger::from_env(env_logger::Env::default().default_filter_or("info"))
+		.format(logging::gke::format)
 		.init();
 
 	let db = DB::open_default(&config.db_path)?;


### PR DESCRIPTION
# Status

The work is ready, although @haikoschol wants to run this branch on staging to see if it behaves as expected in practice. Therefore, the PR has been moved to Draft for the time being.

# Description

closes #231

https://github.com/paritytech/parity-processbot/issues/231#issuecomment-795455441 discusses the format and approach taken here

Output looks like:

```
{"severity":"INFO","message":"Foo","timestamp":"2021-03-10T14:35:17.401461119Z"}
```