### PR TITLE
Commit through the Github API for verification's sake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM paritytech/ci-linux:10a6c216-20200625
+FROM docker.io/paritytech/ci-linux:10a6c216-20200625
 
 COPY parity-processbot /usr/local/bin/parity-processbot
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -64,3 +64,8 @@ pub const SUBSTRATE_TEAM_LEADS_GROUP: &str = "substrateteamleads";
 pub const CORE_DEVS_GROUP: &str = "core-devs";
 
 pub const PROCESS_FILE: &str = "Process.json";
+
+pub enum MergeWaitMode {
+	DoNotWait,
+	CanWait,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,6 +94,11 @@ pub enum Error {
 		source: tokio::io::Error,
 	},
 
+	#[snafu(display("IO: {}", source))]
+	StdIO {
+		source: std::io::Error,
+	},
+
 	/// Data requested was not found or valid.
 	#[snafu(display("Missing data"))]
 	MissingData {},

--- a/src/github.rs
+++ b/src/github.rs
@@ -21,6 +21,30 @@ pub struct PullRequest {
 	pub repository: Option<Repository>,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct TreeObject<'a> {
+	pub path: &'a str,
+	pub content: String,
+	// file mode in the Linux format as a string e.g. "100644"
+	pub mode: String,
+}
+
+#[derive(Deserialize)]
+pub struct CreatedTree {
+	pub sha: String,
+}
+
+#[derive(Deserialize)]
+pub struct CreatedCommit {
+	pub sha: String,
+}
+
+#[derive(Deserialize)]
+pub struct CreatedRef {
+	#[serde(rename = "ref")]
+	pub ref_field: Option<String>,
+}
+
 impl HasIssueDetails for PullRequest {
 	fn get_issue_details(&self) -> Option<(String, String, i64)> {
 		if let Some(Repository {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -28,3 +28,15 @@ macro_rules! COMPANION_SHORT_REGEX {
 		)
 	};
 }
+#[macro_export]
+macro_rules! results {
+    ($e:expr $(, $es:expr)*$(,)? $(;# $($i:ident)*)?) => {
+		match $e {
+			Ok(x) => results!($($es),* ;# $($($i)*)? x),
+			Err(e) => Err(e)
+		}
+    };
+    ($(;# $($i:ident)*)?) => {
+        Ok(($($($i),*)?))
+    };
+}


### PR DESCRIPTION
See #286 for motivation

See https://github.com/paritytech/companion-for-processbot-staging/pull/6 for how it works. The functionality won't be changed, only the bot commits will be verified now (https://github.com/paritytech/companion-for-processbot-staging/pull/6/commits/a7a40ec558784e1de7e45fda3b2b092a04142730).

**Note**: needs "Contents" Github App permission for this to work.

This approach of committing through the API for bot verification is based on

- https://github.community/t/how-to-properly-gpg-sign-github-app-bot-created-commits/131364/2
- https://gist.github.com/harlantwood/2935203

closes #286