### PR TITLE
On recoverable merge failures, register the PR so that it can continue to be processed later

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -192,8 +192,13 @@ pub enum Error {
 		err: String,
 	},
 
-	#[snafu(display("Error was skipped",))]
-	Skipped {},
+	#[snafu(display(
+		"Merge failure was skipped (will be solved later): {}",
+		msg
+	))]
+	MergeFailureWillBeSolvedLater {
+		msg: String,
+	},
 }
 
 impl Error {


### PR DESCRIPTION
Shown in https://github.com/paritytech/substrate/pull/8910#issuecomment-848693484

The MR could not be merged in the first attempt

> 2021-05-26 08:31:56 response '405 Method Not Allowed' for https://api.github.com/repos/paritytech/substrate/pulls/8910/merge

Then the error was ignored because some status was late

> 2021-05-26 08:31:56 Ignoring merge failure due to pending required status; message: "Required status check "continuous-integration/gitlab-check-polkadot-companion-build" is pending."

In that case, the PR should have be registered for later processing in the database. In actuality it was not doing anything and just failing silently.