### PR TITLE
Change CI variables source to Vault

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,6 +90,26 @@ dockerize-processbot:
 .deploy-k8s:                       &deploy-k8s
   image:                           paritytech/kubetools:3.5.3
   interruptible:                   true
+  variables:
+    VAULT_SERVER_URL:              "https://vault.parity-mgmt-vault.parity.io"
+    VAULT_AUTH_PATH:               "gitlab-parity-io-jwt"
+    VAULT_AUTH_ROLE:               "cicd_gitlab_parity_${CI_PROJECT_NAME}"
+  secrets:
+    BAMBOO_TOKEN:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/BAMBOO_TOKEN@kv
+      file:                        false
+    GITLAB_PRIVATE_TOKEN:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/GITLAB_PRIVATE_TOKEN@kv
+      file:                        false
+    MATRIX_ACCESS_TOKEN:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/MATRIX_ACCESS_TOKEN@kv
+      file:                        false
+    PROCESSBOT_KEY:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/$CI_ENVIRONMENT_NAME/PROCESSBOT_KEY@kv
+      file:                        false
+    WEBHOOK_SECRET:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/$CI_ENVIRONMENT_NAME/WEBHOOK_SECRET@kv
+      file:                        false
   script:
     - helm upgrade processbot kubernetes/processbot
       --install

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,9 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       3
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
+  VAULT_SERVER_URL:                "https://vault.parity-mgmt-vault.parity.io"
+  VAULT_AUTH_PATH:                 "gitlab-parity-io-jwt"
+  VAULT_AUTH_ROLE:                 "cicd_gitlab_parity_${CI_PROJECT_NAME}"
 
 stages:
   - check
@@ -65,13 +68,20 @@ test-build:
     GIT_STRATEGY:                  none
     DOCKER_IMAGE:                  "${CI_REGISTRY}/${KUBE_NAMESPACE}"
   interruptible:                   true
+  secrets:
+      DOCKER_HUB_USER:
+        vault:                     cicd/gitlab/parity/DOCKER_HUB_USER@kv
+        file:                      false
+      DOCKER_HUB_PASS:
+        vault:                     cicd/gitlab/parity/DOCKER_HUB_PASS@kv
+        file:                      false
   script:
     - cd ./artifacts
     - buildah bud
       --format=docker
       --tag "$DOCKER_IMAGE:$CI_COMMIT_REF_NAME" .
-    - echo "$Docker_Hub_Pass_Parity" |
-        buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
+    - echo "$DOCKER_HUB_PASS" |
+        buildah login --username "$DOCKER_HUB_USER" --password-stdin docker.io
     - buildah push --format=v2s2 "$DOCKER_IMAGE:$CI_COMMIT_REF_NAME"
   tags:
     - kubernetes-parity-build
@@ -90,10 +100,6 @@ dockerize-processbot:
 .deploy-k8s:                       &deploy-k8s
   image:                           paritytech/kubetools:3.5.3
   interruptible:                   true
-  variables:
-    VAULT_SERVER_URL:              "https://vault.parity-mgmt-vault.parity.io"
-    VAULT_AUTH_PATH:               "gitlab-parity-io-jwt"
-    VAULT_AUTH_ROLE:               "cicd_gitlab_parity_${CI_PROJECT_NAME}"
   secrets:
     BAMBOO_TOKEN:
       vault:                       cicd/gitlab/$CI_PROJECT_PATH/BAMBOO_TOKEN@kv


### PR DESCRIPTION
Change behavior of the pipeline to use Vault secrets instead of GitLab project variables.
!!! This PR can be merged only after this [MR](https://gitlab.parity.io/parity/infrastructure/cloud-infra/-/merge_requests/543) will get merged.