### PR TITLE
Integration tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,57 +8,53 @@ variables:
   VAULT_AUTH_PATH:                 "gitlab-parity-io-jwt"
   VAULT_AUTH_ROLE:                 "cicd_gitlab_parity_${CI_PROJECT_NAME}"
 
-stages:
-  - check
-  - test
-  - dockerize
-  - deploy-staging
-  - deploy
-
-.docker-env:                       &docker-env
-  image:                           paritytech/ci-linux:production
-  before_script:
-    - rustup show
-    - cargo --version
-    - sccache -s
+default:
+  image: paritytech/ci-linux:production
   retry:
     max: 2
     when:
       - runner_system_failure
       - unknown_failure
       - api_failure
-  dependencies:                    []
-  interruptible:                   true
   tags:
     - linux-docker
+
+stages:
+  - check
+  - test
+  - dockerize
+  - deploy
 
 #### stage:                        check
 
 check:
   stage:                           check
-  <<:                              *docker-env
   script:
     # TODO: create processbot CI image which already has rustfmt and clippy
     - rustup component add rustfmt clippy
     - cargo fmt --all -- --check
-    - cargo clippy -- -Dwarnings
+    - cargo check --all-targets --workspace
+    - cargo clippy --all-targets --workspace -- -Dwarnings
 
 #### stage:                        test
 
-test-build:
+integration-tests:
   stage:                           test
-  <<:                              *docker-env
+  script:
+    - ./scripts/run_integration_tests.sh
+
+build:
+  stage:                           test
   script:
     - cargo test --release --all
     - cargo build --release
-  after_script:
     - mkdir -p ./artifacts/
     - cp ${CARGO_TARGET_DIR}/release/parity-processbot ./artifacts/
     - cp ./Dockerfile ./artifacts/
   artifacts:
     name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     when:                          on_success
-    expire_in:                     7 days
+    expire_in:                     1 hour
     paths:
       - ./artifacts/
 
@@ -92,7 +88,7 @@ dockerize-processbot:
   stage:                           dockerize
   <<:                              *build_and_push
   needs:
-    - job:                         test-build
+    - job:                         build
       artifacts:                   true
   only:
     - tags
@@ -136,7 +132,7 @@ dockerize-processbot:
       --set "processbot.secret.GITHUB_APP_ID=${GITHUB_APP_ID}"
 
 deploy-staging:
-  stage:                           deploy-staging
+  stage:                           deploy
   <<:                              *deploy-k8s
   environment:
     name: staging

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00d68a33ebc8b57800847d00787307f84a562224a14db069b0acefe4c2abbf5d"
 dependencies = [
  "async-task",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -192,6 +192,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +222,12 @@ checksum = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
 dependencies = [
  "loom",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cache-padded"
@@ -317,6 +334,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "terminal_size",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +363,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.5",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +380,16 @@ checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
  "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -398,6 +448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +503,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64b0126b293b050395b37b10489951590ed024c03d7df4f249d219c8ded7cbf"
 
 [[package]]
+name = "flexi_logger"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab94b6ac8eb69f1496a6993f26f785b5fd6d99b7416023eb2a6175c0b242b1"
+dependencies = [
+ "atty",
+ "chrono",
+ "glob",
+ "lazy_static",
+ "log",
+ "regex",
+ "thiserror",
+ "yansi",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +538,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "fuchsia-zircon"
@@ -642,7 +724,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
 dependencies = [
- "bytes",
+ "bytes 0.5.5",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -651,8 +733,27 @@ dependencies = [
  "indexmap",
  "log",
  "slab",
- "tokio",
- "tokio-util",
+ "tokio 0.2.21",
+ "tokio-util 0.3.1",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
+dependencies = [
+ "bytes 1.1.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.12.0",
+ "tokio-util 0.6.8",
+ "tracing",
 ]
 
 [[package]]
@@ -685,7 +786,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes",
+ "bytes 0.5.5",
  "fnv",
  "itoa",
 ]
@@ -696,8 +797,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.5",
  "http",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+dependencies = [
+ "bytes 1.1.0",
+ "http",
+ "pin-project-lite 0.2.7",
 ]
 
 [[package]]
@@ -705,6 +817,34 @@ name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
+name = "httptest"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5858cc7b673d0397ffd4cdee93f11eb2fa08a2b0b5e35ae03d6b480a4abe171d"
+dependencies = [
+ "bstr",
+ "bytes 1.1.0",
+ "crossbeam-channel",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "hyper 0.14.4",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded 0.7.0",
+ "tokio 1.12.0",
+]
 
 [[package]]
 name = "humantime"
@@ -721,21 +861,45 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
 dependencies = [
- "bytes",
+ "bytes 0.5.5",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.2.5",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "httparse",
  "itoa",
  "log",
- "pin-project",
+ "pin-project 0.4.22",
  "socket2",
  "time",
- "tokio",
+ "tokio 0.2.21",
  "tower-service",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.6",
+ "http",
+ "http-body 0.4.3",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.8",
+ "socket2",
+ "tokio 1.12.0",
+ "tower-service",
+ "tracing",
  "want",
 ]
 
@@ -745,10 +909,10 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
 dependencies = [
- "bytes",
- "hyper",
+ "bytes 0.5.5",
+ "hyper 0.13.6",
  "native-tls",
- "tokio",
+ "tokio 0.2.21",
  "tokio-tls",
 ]
 
@@ -759,7 +923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81d7ed6ec7d25c4de28b999a5693f14609a8b756137b1b4cb4927d119f59ef25"
 dependencies = [
  "base64 0.11.0",
- "bytes",
+ "bytes 0.5.5",
  "http",
  "httparse",
  "language-tags",
@@ -789,6 +953,21 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "insta"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15226a375927344c78d39dc6b49e2d5562a5b0705e26a589093c6792e52eed8e"
+dependencies = [
+ "console",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "similar",
+ "uuid",
 ]
 
 [[package]]
@@ -1017,13 +1196,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.7",
+ "ntapi",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "mio-named-pipes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
 dependencies = [
  "log",
- "mio",
+ "mio 0.6.22",
  "miow 0.3.7",
  "winapi 0.3.8",
 ]
@@ -1036,7 +1228,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.22",
 ]
 
 [[package]]
@@ -1097,6 +1289,15 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
+dependencies = [
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1202,11 +1403,14 @@ dependencies = [
  "dotenv",
  "env_logger",
  "eventsource",
+ "flexi_logger",
  "futures",
  "futures-util",
  "html-escape",
- "hyper",
+ "httptest",
+ "hyper 0.13.6",
  "hyperx",
+ "insta",
  "itertools",
  "jsonwebtoken",
  "lazy_static",
@@ -1220,8 +1424,9 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "snafu",
+ "tempfile",
  "thiserror",
- "tokio",
+ "tokio 0.2.21",
  "toml",
  "url",
 ]
@@ -1285,7 +1490,16 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.22",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+dependencies = [
+ "pin-project-internal 1.0.8",
 ]
 
 [[package]]
@@ -1293,6 +1507,17 @@ name = "pin-project-internal"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1425,6 +1650,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,13 +1677,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
 dependencies = [
  "base64 0.12.2",
- "bytes",
+ "bytes 0.5.5",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http",
- "http-body",
- "hyper",
+ "http-body 0.3.1",
+ "hyper 0.13.6",
  "hyper-tls",
  "js-sys",
  "lazy_static",
@@ -1464,8 +1695,8 @@ dependencies = [
  "pin-project-lite 0.1.7",
  "serde",
  "serde_json",
- "serde_urlencoded",
- "tokio",
+ "serde_urlencoded 0.6.1",
+ "tokio 0.2.21",
  "tokio-tls",
  "url",
  "wasm-bindgen",
@@ -1609,18 +1840,18 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.114"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.114"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1629,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.55"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -1651,13 +1882,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.8.13"
+name = "serde_urlencoded"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
 dependencies = [
  "dtoa",
- "linked-hash-map",
+ "indexmap",
  "serde",
  "yaml-rust",
 ]
@@ -1677,6 +1920,12 @@ dependencies = [
  "arc-swap",
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
 
 [[package]]
 name = "simple_asn1"
@@ -1801,6 +2050,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,14 +2119,14 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
- "bytes",
+ "bytes 0.5.5",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
  "libc",
  "memchr",
- "mio",
+ "mio 0.6.22",
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
@@ -1875,6 +2134,22 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "tokio-macros",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "tokio"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+dependencies = [
+ "autocfg",
+ "bytes 1.1.0",
+ "libc",
+ "memchr",
+ "mio 0.7.14",
+ "num_cpus",
+ "pin-project-lite 0.2.7",
  "winapi 0.3.8",
 ]
 
@@ -1896,7 +2171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -1905,12 +2180,26 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.5",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite 0.1.7",
- "tokio",
+ "tokio 0.2.21",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.7",
+ "tokio 1.12.0",
 ]
 
 [[package]]
@@ -1927,6 +2216,26 @@ name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
+name = "tracing"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite 0.2.7",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "try-lock"
@@ -1995,6 +2304,12 @@ name = "utf8-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "vcpkg"
@@ -2196,9 +2511,15 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,9 @@ url = "2.1.1"
 html-escape = "0.2.9"
 cargo-lock = "^7.0.1"
 eventsource = "0.5.0"
+
+[dev-dependencies]
+httptest = "0.15.1"
+tempfile = "3"
+insta = "1.7.1"
+flexi_logger = "0.17.1"

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Webhook Events in your local instance of processbot.
 
 After setting up the environment, run: `cargo run`
 
+For executing the integration tests, run: `./scripts/run_integration_tests.sh`
+
 # Deployment
 
 The bot is automatically deployed by pushing a tag with one of the following formats

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/env sh
+
+git_daemon_base_path_file="$(mktemp)"
+
+on_exit() {
+	# kill lingering git daemon instances by their "base-path" argument because
+	# the whole process tree is not finished when the main process exits;
+	# targetting the process tree does not work either
+	while IFS= read -r base_path; do
+		>/dev/null pkill -f -- "--base-path=$base_path"
+	done < "$git_daemon_base_path_file"
+
+	rm "$git_daemon_base_path_file"
+}
+trap on_exit EXIT
+
+# --test '*' means only run the integration tests
+# https://github.com/rust-lang/cargo/issues/8396#issuecomment-713126649
+GIT_DAEMON_BASE_PATH_FILE="$git_daemon_base_path_file" cargo test --test '*'

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,9 @@ pub struct MainConfig {
 	pub webhook_proxy_url: Option<String>,
 	pub github_app_id: usize,
 	pub disable_org_check: bool,
+	pub github_api_url: String,
+	pub companion_status_settle_delay: u64,
+	pub merge_command_delay: u64,
 }
 
 impl MainConfig {
@@ -43,6 +46,12 @@ impl MainConfig {
 			})
 			.unwrap_or(false);
 
+		let github_api_url = "https://api.github.com".to_owned();
+
+		let merge_command_delay = 4096;
+
+		let companion_status_settle_delay = 4096;
+
 		Self {
 			installation_login,
 			webhook_secret,
@@ -52,6 +61,9 @@ impl MainConfig {
 			webhook_proxy_url,
 			github_app_id,
 			disable_org_check,
+			github_api_url,
+			merge_command_delay,
+			companion_status_settle_delay,
 		}
 	}
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -19,7 +19,6 @@ pub struct PullRequest {
 	pub body: Option<String>,
 	pub head: Head,
 	pub base: Base,
-	pub repository: Option<Repository>,
 	pub mergeable: Option<bool>,
 	pub merged: bool,
 	pub maintainer_can_modify: bool,
@@ -181,11 +180,9 @@ pub struct Label {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Repository {
 	pub name: String,
-	pub full_name: Option<String>,
-	pub owner: Option<User>,
+	pub full_name: String,
+	pub owner: User,
 	pub html_url: String,
-	pub issues_url: Option<String>,
-	pub pulls_url: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -261,14 +258,11 @@ pub enum IssueCommentAction {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CheckRuns {
-	pub total_count: i64,
 	pub check_runs: Vec<CheckRun>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HeadRepo {
-	pub id: i64,
-	pub url: String,
 	pub name: String,
 	pub owner: User,
 }
@@ -308,7 +302,7 @@ pub struct CheckRun {
 pub struct WebhookIssueComment {
 	pub number: i64,
 	pub html_url: String,
-	pub repository_url: Option<String>,
+	pub repository_url: String,
 	pub pull_request: Option<PlaceholderDeserializationItem>,
 }
 

--- a/src/github_bot/issue.rs
+++ b/src/github_bot/issue.rs
@@ -6,16 +6,13 @@ impl GithubBot {
 	pub async fn issue_events(
 		&self,
 		owner: &str,
-		repo_name: &str,
-		issue_number: i64,
+		repo: &str,
+		number: i64,
 	) -> Result<Vec<github::IssueEvent>> {
 		self.client
 			.get_all(format!(
-				"{base_url}/repos/{owner}/{repo_name}/issues/{issue_number}/events",
-				base_url = Self::BASE_URL,
-				owner = owner,
-				repo_name = repo_name,
-				issue_number = issue_number
+				"{}/repos/{}/{}/issues/{}/events",
+				self.github_api_url, owner, repo, number
 			))
 			.await
 	}
@@ -23,16 +20,13 @@ impl GithubBot {
 	pub async fn create_issue_comment(
 		&self,
 		owner: &str,
-		repo_name: &str,
-		issue_number: i64,
+		repo: &str,
+		number: i64,
 		comment: &str,
 	) -> Result<()> {
 		let url = format!(
-			"{base}/repos/{owner}/{repo}/issues/{issue_number}/comments",
-			base = Self::BASE_URL,
-			owner = owner,
-			repo = repo_name,
-			issue_number = issue_number
+			"{}/repos/{}/{}/issues/{}/comments",
+			self.github_api_url, owner, repo, number
 		);
 		self.client
 			.post_response(&url, &serde_json::json!({ "body": comment }))

--- a/src/github_bot/mod.rs
+++ b/src/github_bot/mod.rs
@@ -1,4 +1,4 @@
-use crate::{constants::*, github::*, Result};
+use crate::{config::MainConfig, constants::*, github::*, Result};
 use futures_util::TryFutureExt;
 
 pub mod issue;
@@ -9,45 +9,28 @@ pub mod team;
 
 pub struct GithubBot {
 	pub client: crate::http::Client,
+	github_api_url: String,
 }
 
 impl GithubBot {
-	pub(crate) const BASE_URL: &'static str = "https://api.github.com";
+	pub fn new(config: &MainConfig) -> Self {
+		let client = crate::http::Client::new(config);
 
-	pub fn new(
-		private_key: impl Into<Vec<u8>>,
-		installation_login: &str,
-		github_app_id: usize,
-	) -> Result<Self> {
-		let client = crate::http::Client::new(
-			private_key.into(),
-			installation_login.to_owned(),
-			github_app_id,
-		);
-
-		Ok(Self { client })
-	}
-
-	pub async fn installation_repositories(
-		&self,
-	) -> Result<InstallationRepositories> {
-		self.client
-			.get(&format!("{}/installation/repositories", Self::BASE_URL))
-			.await
+		Self {
+			client,
+			github_api_url: config.github_api_url.clone(),
+		}
 	}
 
 	pub async fn status(
 		&self,
 		owner: &str,
-		repo_name: &str,
+		repo: &str,
 		sha: &str,
 	) -> Result<CombinedStatus> {
 		let url = format!(
-			"{base_url}/repos/{owner}/{repo}/commits/{sha}/status",
-			base_url = Self::BASE_URL,
-			owner = owner,
-			repo = repo_name,
-			sha = sha
+			"{}/repos/{}/{}/commits/{}/status",
+			self.github_api_url, owner, repo, sha
 		);
 		self.client.get(url).await
 	}
@@ -55,15 +38,12 @@ impl GithubBot {
 	pub async fn check_runs(
 		&self,
 		owner: &str,
-		repo_name: &str,
+		repo: &str,
 		sha: &str,
 	) -> Result<CheckRuns> {
 		let url = format!(
-			"{base_url}/repos/{owner}/{repo}/commits/{sha}/check-runs",
-			base_url = Self::BASE_URL,
-			owner = owner,
-			repo = repo_name,
-			sha = sha
+			"{}/repos/{}/{}/commits/{}/check-runs",
+			self.github_api_url, owner, repo, sha
 		);
 		self.client.get(url).await
 	}
@@ -71,27 +51,21 @@ impl GithubBot {
 	pub async fn contents(
 		&self,
 		owner: &str,
-		repo_name: &str,
+		repo: &str,
 		path: &str,
 		ref_field: &str,
 	) -> Result<Contents> {
 		let url = &format!(
-			"{base_url}/repos/{owner}/{repo_name}/contents/{path}?ref={ref_field}",
-			base_url = Self::BASE_URL,
-			owner = owner,
-			repo_name = repo_name,
-			path = path,
-			ref_field = ref_field,
+			"{}/repos/{}/{}/contents/{}?ref={}",
+			self.github_api_url, owner, repo, path, ref_field
 		);
 		self.client.get(url).await
 	}
 
 	pub async fn org_member(&self, org: &str, username: &str) -> Result<bool> {
 		let url = &format!(
-			"{base_url}/orgs/{org}/members/{username}",
-			base_url = Self::BASE_URL,
-			org = org,
-			username = username,
+			"{}/orgs/{}/members/{}",
+			self.github_api_url, org, username
 		);
 		let status = self.client.get_status(url).await?;
 		Ok(status == 204) // Github API returns HTTP 204 (No Content) if the user is a member
@@ -100,15 +74,12 @@ impl GithubBot {
 	pub async fn approve_merge_request(
 		&self,
 		owner: &str,
-		repo_name: &str,
+		repo: &str,
 		pr_number: i64,
 	) -> Result<Review> {
 		let url = &format!(
 			"{}/repos/{}/{}/pulls/{}/reviews",
-			Self::BASE_URL,
-			owner,
-			repo_name,
-			pr_number
+			self.github_api_url, owner, repo, pr_number
 		);
 		let body = &serde_json::json!({ "event": "APPROVE" });
 		self.client.post(url, body).await
@@ -117,17 +88,13 @@ impl GithubBot {
 	pub async fn clear_merge_request_approval(
 		&self,
 		owner: &str,
-		repo_name: &str,
+		repo: &str,
 		pr_number: i64,
 		review_id: i64,
 	) -> Result<Review> {
 		let url = &format!(
 			"{}/repos/{}/{}/pulls/{}/reviews/{}/dismissals",
-			Self::BASE_URL,
-			owner,
-			repo_name,
-			pr_number,
-			review_id
+			self.github_api_url, owner, repo, pr_number, review_id
 		);
 		let body = &serde_json::json!({
 			"message": "Merge failed despite bot approval, therefore the approval will be dismissed."

--- a/src/github_bot/project.rs
+++ b/src/github_bot/project.rs
@@ -8,14 +8,12 @@ impl GithubBot {
 	pub async fn projects(
 		&self,
 		owner: &str,
-		repo_name: &str,
+		repo: &str,
 	) -> Result<Vec<github::Project>> {
 		self.client
 			.get_all(&format!(
-				"{base_url}/repos/{owner}/{repo_name}/projects",
-				base_url = Self::BASE_URL,
-				owner = owner,
-				repo_name = repo_name,
+				"{}/repos/{}/{}/projects",
+				self.github_api_url, owner, repo
 			))
 			.await
 	}
@@ -25,11 +23,11 @@ impl GithubBot {
 	pub async fn active_project_events(
 		&self,
 		owner: &str,
-		repo_name: &str,
-		issue_number: i64,
+		repo: &str,
+		number: i64,
 	) -> Result<Vec<github::IssueEvent>> {
 		let events = self
-			.issue_events(owner, repo_name, issue_number)
+			.issue_events(owner, repo, number)
 			.await?
 			.into_iter()
 			.filter(|issue_event| {

--- a/src/github_bot/pull_request.rs
+++ b/src/github_bot/pull_request.rs
@@ -6,16 +6,13 @@ impl GithubBot {
 	pub async fn pull_request(
 		&self,
 		owner: &str,
-		repo_name: &str,
-		pull_number: i64,
+		repo: &str,
+		number: i64,
 	) -> Result<github::PullRequest> {
 		self.client
 			.get(format!(
-				"{base_url}/repos/{owner}/{repo}/pulls/{pull_number}",
-				base_url = Self::BASE_URL,
-				owner = owner,
-				repo = repo_name,
-				pull_number = pull_number
+				"{}/repos/{}/{}/pulls/{}",
+				self.github_api_url, owner, repo, number
 			))
 			.await
 	}
@@ -23,16 +20,13 @@ impl GithubBot {
 	pub async fn pull_request_with_head(
 		&self,
 		owner: &str,
-		repo_name: &str,
+		repo: &str,
 		head: &str,
 	) -> Result<Option<github::PullRequest>> {
 		self.client
 			.get_all(format!(
-				"{base_url}/repos/{owner}/{repo}/pulls?head={head}",
-				base_url = Self::BASE_URL,
-				owner = owner,
-				repo = repo_name,
-				head = head,
+				"{}/repos/{}/{}/pulls?head={}",
+				self.github_api_url, owner, repo, head
 			))
 			.await
 			.map(|v| v.first().cloned())
@@ -41,16 +35,13 @@ impl GithubBot {
 	pub async fn merge_pull_request(
 		&self,
 		owner: &str,
-		repo_name: &str,
+		repo: &str,
 		number: i64,
 		head_sha: &str,
 	) -> Result<()> {
 		let url = format!(
-			"{base_url}/repos/{owner}/{repo}/pulls/{number}/merge",
-			base_url = Self::BASE_URL,
-			owner = owner,
-			repo = repo_name,
-			number = number,
+			"{}/repos/{}/{}/pulls/{}/merge",
+			self.github_api_url, owner, repo, number
 		);
 		let params = serde_json::json!({
 			"sha": head_sha,

--- a/src/github_bot/team.rs
+++ b/src/github_bot/team.rs
@@ -4,12 +4,8 @@ use super::GithubBot;
 
 impl GithubBot {
 	pub async fn team(&self, owner: &str, slug: &str) -> Result<github::Team> {
-		let url = format!(
-			"{base_url}/orgs/{owner}/teams/{slug}",
-			base_url = Self::BASE_URL,
-			owner = owner,
-			slug = slug
-		);
+		let url =
+			format!("{}/orgs/{}/teams/{}", self.github_api_url, owner, slug);
 		self.client.get(url).await
 	}
 
@@ -18,7 +14,10 @@ impl GithubBot {
 		team_id: i64,
 	) -> Result<Vec<github::User>> {
 		self.client
-			.get_all(format!("{}/teams/{}/members", Self::BASE_URL, team_id))
+			.get_all(format!(
+				"{}/teams/{}/members",
+				self.github_api_url, team_id,
+			))
 			.await
 	}
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! PR_HTML_URL_REGEX {
     () => {
-        r"(?P<html_url>https://github.com/(?P<owner>[^/\n]+)/(?P<repo>[^/\n]+)/pull/(?P<number>[[:digit:]]+))"
+        r"(?P<html_url>https://[^/]+/(?P<owner>[^/\n]+)/(?P<repo>[^/\n]+)/pull/(?P<number>[[:digit:]]+))"
     };
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use tokio::sync::Mutex;
 mod logging;
 
 use parity_processbot::{
-	config::MainConfig, constants::*, github::Payload, github_bot, server::*,
+	config::MainConfig, constants::*, github::Payload, github_bot, server,
 	webhook::*,
 };
 
@@ -53,11 +53,7 @@ fn main() -> anyhow::Result<()> {
 
 	let db = DB::open_default(&config.db_path)?;
 
-	let github_bot = github_bot::GithubBot::new(
-		config.private_key.clone(),
-		&config.installation_login,
-		config.github_app_id,
-	)?;
+	let github_bot = github_bot::GithubBot::new(&config);
 
 	let webhook_proxy_url = config.webhook_proxy_url.clone();
 
@@ -106,7 +102,7 @@ fn main() -> anyhow::Result<()> {
 			});
 		}
 	} else {
-		rt.block_on(init_server(socket, app_state))?;
+		rt.block_on(server::init(socket, app_state))?;
 	}
 
 	Ok(())

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -204,11 +204,16 @@ pub async fn handle_payload(
 					WebhookIssueComment {
 						number,
 						html_url,
-						repository_url: Some(repo_url),
+						repository_url,
 						pull_request: Some(_),
 					} => {
 						let (sha, result) = handle_comment(
-							body, login, *number, html_url, repo_url, state,
+							body,
+							login,
+							*number,
+							html_url,
+							repository_url,
+							state,
 						)
 						.await;
 						(
@@ -953,7 +958,7 @@ async fn handle_comment(
 			// As a workaround we'll wait for long enough so that Github hopefully has time to update the
 			// API and make our merges succeed. A proper workaround would also entail retrying every X
 			// seconds for recoverable errors such as "required statuses are missing or pending".
-			delay_for(Duration::from_millis(4096)).await;
+			delay_for(Duration::from_millis(config.merge_command_delay)).await;
 		};
 
 		let pr = github_bot.pull_request(owner, repo, number).await?;

--- a/tests/helpers/cmd.rs
+++ b/tests/helpers/cmd.rs
@@ -1,0 +1,85 @@
+use std::ffi::OsStr;
+use std::fmt::Display;
+use std::path::Path;
+use std::process::Command;
+use std::process::Stdio;
+
+pub enum CmdConfiguration<'a> {
+	SilentStderrStartingWith(&'a [&'a str]),
+}
+
+pub fn exec<Cmd, Dir>(
+	cmd: Cmd,
+	args: &[&str],
+	dir: Option<Dir>,
+	conf: Option<CmdConfiguration<'_>>,
+) where
+	Cmd: AsRef<OsStr> + Display,
+	Dir: AsRef<Path>,
+{
+	let mut cmd = Command::new(cmd);
+	let cmd = {
+		let cmd = cmd.args(args).stdout(Stdio::null());
+		if let Some(dir) = dir {
+			cmd.current_dir(dir)
+		} else {
+			cmd
+		}
+	};
+
+	println!("Executing {:?}", cmd);
+
+	match conf {
+		Some(CmdConfiguration::SilentStderrStartingWith(
+			prefixes_to_ignore,
+		)) => {
+			let out = cmd
+				.stderr(Stdio::piped())
+				.spawn()
+				.unwrap()
+				.wait_with_output()
+				.unwrap();
+
+			let err = String::from_utf8_lossy(&out.stdout);
+			let err = err.trim();
+			if err.is_empty() {
+				return;
+			} else {
+				for prefix_to_ignore in prefixes_to_ignore {
+					if err.starts_with(prefix_to_ignore) {
+						return;
+					}
+				}
+			};
+			println!("STDERR: {}", err);
+		}
+		_ => {
+			cmd.spawn().unwrap().wait().unwrap();
+		}
+	}
+}
+
+pub fn get_cmd_output<Cmd, Dir>(
+	cmd: Cmd,
+	args: &[&str],
+	dir: Option<Dir>,
+) -> String
+where
+	Cmd: AsRef<OsStr> + Display,
+	Dir: AsRef<Path>,
+{
+	let mut cmd = Command::new(cmd);
+	let cmd = {
+		let cmd = cmd.args(args).stdout(Stdio::piped());
+		if let Some(dir) = dir {
+			cmd.current_dir(dir)
+		} else {
+			cmd
+		}
+	};
+
+	println!("Getting output of {:?}", cmd);
+
+	let output = cmd.spawn().unwrap().wait_with_output().unwrap();
+	String::from_utf8_lossy(&output.stdout).trim().to_string()
+}

--- a/tests/helpers/constants.rs
+++ b/tests/helpers/constants.rs
@@ -1,0 +1,3 @@
+pub const I64_PLACEHOLDER_WHICH_DOES_NOT_MATTER: i64 = 0;
+pub const USIZE_PLACEHOLDER_WHICH_DOES_NOT_MATTER: usize = 0;
+pub const URL_PLACEHOLDER_WHICH_DOES_NOT_MATTER: &str = "https://localhost";

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,0 +1,82 @@
+use std::fs::{self, remove_dir_all, remove_file, File};
+use std::io::Read;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+
+pub mod cmd;
+pub mod constants;
+pub mod setup;
+
+use cmd::exec;
+
+pub fn get_available_port() -> Option<u16> {
+	for port in 1025..65535 {
+		if TcpListener::bind(("127.0.0.1", port)).is_ok() {
+			return Some(port);
+		}
+	}
+
+	None
+}
+
+pub fn read_snapshot(log_dir: PathBuf, texts_to_hide: &[&str]) -> String {
+	let entry = log_dir.read_dir().unwrap().next().unwrap().unwrap();
+	let mut file = File::open(entry.path()).unwrap();
+	let mut buf = String::new();
+	file.read_to_string(&mut buf).unwrap();
+	for text_to_hide in texts_to_hide.iter() {
+		buf = buf.replace(text_to_hide, "{REDACTED}");
+	}
+	buf
+}
+
+pub fn clean_directory(dir: PathBuf) {
+	for f in dir.read_dir().unwrap() {
+		let f = f.unwrap();
+		let _ = if f.metadata().unwrap().is_dir() {
+			remove_dir_all(f.path())
+		} else {
+			remove_file(f.path())
+		};
+	}
+}
+
+pub fn initialize_repository(repo_dir: &Path, initial_branch: &str) {
+	exec::<&str, PathBuf>(
+		"git",
+		&[
+			"init",
+			"--initial-branch",
+			initial_branch,
+			&repo_dir.display().to_string(),
+		],
+		None,
+		None,
+	);
+	exec(
+		"git",
+		&["config", "--local", "user.name", "processbot"],
+		Some(repo_dir),
+		None,
+	);
+	exec(
+		"git",
+		&["config", "--local", "user.email", "foo@bar.com"],
+		Some(repo_dir),
+		None,
+	);
+	exec(
+		"git",
+		&["config", "--local", "advice.detachedHead", "false"],
+		Some(repo_dir),
+		None,
+	);
+	fs::write(&repo_dir.join("README"), "").unwrap();
+	exec("git", &["add", "."], Some(&repo_dir), None);
+	exec(
+		"git",
+		&["commit", "-m", "initial commit"],
+		Some(&repo_dir),
+		None,
+	);
+}

--- a/tests/helpers/setup.rs
+++ b/tests/helpers/setup.rs
@@ -1,0 +1,452 @@
+use httptest::{matchers::*, responders::*, Expectation, Server};
+use parity_processbot::{self, github};
+use serde_json::json;
+use std::{
+	env, fs,
+	io::Write,
+	path::PathBuf,
+	process::{self, Command, Stdio},
+};
+use tempfile::TempDir;
+
+use super::{cmd::*, constants::*, *};
+
+pub struct CommonSetupOutput {
+	pub log_dir: TempDir,
+	pub db_dir: TempDir,
+	pub git_daemon_handle: process::Child,
+	pub git_daemon_dir: TempDir,
+	pub private_key: Vec<u8>,
+	pub github_api: Server,
+	pub github_api_url: String,
+	pub owner: github::User,
+	pub repo_name: &'static str,
+	pub repo_dir: PathBuf,
+	pub repo_full_name: String,
+	pub github_app_id: usize,
+	pub next_team_id: i64,
+}
+pub fn common_setup() -> CommonSetupOutput {
+	let git_daemon_base_path_file =
+		env::var("GIT_DAEMON_BASE_PATH_FILE").unwrap();
+
+	let log_dir = tempfile::tempdir().unwrap();
+	flexi_logger::Logger::with_env_or_str("info")
+		.log_to_file()
+		.directory((&log_dir).path().to_path_buf())
+		.duplicate_to_stdout(flexi_logger::Duplicate::All)
+		.start()
+		.unwrap();
+
+	let db_dir = tempfile::tempdir().unwrap();
+
+	let git_daemon_dir = tempfile::tempdir().unwrap();
+	let git_daemon_dir_path_str = git_daemon_dir.path().display().to_string();
+	{
+		let mut file = std::fs::OpenOptions::new()
+			.write(true)
+			.append(true)
+			.open(git_daemon_base_path_file)
+			.unwrap();
+		writeln!(file, "{}", &git_daemon_dir_path_str).unwrap();
+	}
+	clean_directory(git_daemon_dir.path().to_path_buf());
+
+	let owner = github::User {
+		login: "owner".to_string(),
+		type_field: Some(github::UserType::User),
+	};
+	let private_key = "
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDJETqse41HRBsc
+7cfcq3ak4oZWFCoZlcic525A3FfO4qW9BMtRO/iXiyCCHn8JhiL9y8j5JdVP2Q9Z
+IpfElcFd3/guS9w+5RqQGgCR+H56IVUyHZWtTJbKPcwWXQdNUX0rBFcsBzCRESJL
+eelOEdHIjG7LRkx5l/FUvlqsyHDVJEQsHwegZ8b8C0fz0EgT2MMEdn10t6Ur1rXz
+jMB/wvCg8vG8lvciXmedyo9xJ8oMOh0wUEgxziVDMMovmC+aJctcHUAYubwoGN8T
+yzcvnGqL7JSh36Pwy28iPzXZ2RLhAyJFU39vLaHdljwthUaupldlNyCfa6Ofy4qN
+ctlUPlN1AgMBAAECggEAdESTQjQ70O8QIp1ZSkCYXeZjuhj081CK7jhhp/4ChK7J
+GlFQZMwiBze7d6K84TwAtfQGZhQ7km25E1kOm+3hIDCoKdVSKch/oL54f/BK6sKl
+qlIzQEAenho4DuKCm3I4yAw9gEc0DV70DuMTR0LEpYyXcNJY3KNBOTjN5EYQAR9s
+2MeurpgK2MdJlIuZaIbzSGd+diiz2E6vkmcufJLtmYUT/k/ddWvEtz+1DnO6bRHh
+xuuDMeJA/lGB/EYloSLtdyCF6sII6C6slJJtgfb0bPy7l8VtL5iDyz46IKyzdyzW
+tKAn394dm7MYR1RlUBEfqFUyNK7C+pVMVoTwCC2V4QKBgQD64syfiQ2oeUlLYDm4
+CcKSP3RnES02bcTyEDFSuGyyS1jldI4A8GXHJ/lG5EYgiYa1RUivge4lJrlNfjyf
+dV230xgKms7+JiXqag1FI+3mqjAgg4mYiNjaao8N8O3/PD59wMPeWYImsWXNyeHS
+55rUKiHERtCcvdzKl4u35ZtTqQKBgQDNKnX2bVqOJ4WSqCgHRhOm386ugPHfy+8j
+m6cicmUR46ND6ggBB03bCnEG9OtGisxTo/TuYVRu3WP4KjoJs2LD5fwdwJqpgtHl
+yVsk45Y1Hfo+7M6lAuR8rzCi6kHHNb0HyBmZjysHWZsn79ZM+sQnLpgaYgQGRbKV
+DZWlbw7g7QKBgQCl1u+98UGXAP1jFutwbPsx40IVszP4y5ypCe0gqgon3UiY/G+1
+zTLp79GGe/SjI2VpQ7AlW7TI2A0bXXvDSDi3/5Dfya9ULnFXv9yfvH1QwWToySpW
+Kvd1gYSoiX84/WCtjZOr0e0HmLIb0vw0hqZA4szJSqoxQgvF22EfIWaIaQKBgQCf
+34+OmMYw8fEvSCPxDxVvOwW2i7pvV14hFEDYIeZKW2W1HWBhVMzBfFB5SE8yaCQy
+pRfOzj9aKOCm2FjjiErVNpkQoi6jGtLvScnhZAt/lr2TXTrl8OwVkPrIaN0bG/AS
+aUYxmBPCpXu3UjhfQiWqFq/mFyzlqlgvuCc9g95HPQKBgAscKP8mLxdKwOgX8yFW
+GcZ0izY/30012ajdHY+/QK5lsMoxTnn0skdS+spLxaS5ZEO4qvPVb8RAoCkWMMal
+2pOhmquJQVDPDLuZHdrIiKiDM20dy9sMfHygWcZjQ4WSxf/J7T9canLZIXFhHAZT
+3wc9h4G8BBCtWN2TN/LsGZdB
+-----END PRIVATE KEY-----
+  "
+	.as_bytes()
+	.to_vec();
+
+	// Set up the Git repository with an initial commit
+	let repo = "repo";
+	let repo_full_name = format!("{}/{}", &owner.login, repo);
+	let repo_dir = git_daemon_dir.path().join(&owner.login).join(repo);
+	let initial_branch = "master";
+	fs::create_dir_all(&repo_dir).unwrap();
+	initialize_repository(&repo_dir, initial_branch);
+
+	let github_api = Server::run();
+	let github_api_url = {
+		let url = github_api.url("").to_string();
+		url[0..url.len() - 1].to_string()
+	};
+
+	github_api.expect(
+		Expectation::matching(request::method_path(
+			"GET",
+			"/app/installations",
+		))
+		.times(0..)
+		.respond_with(json_encoded(vec![github::Installation {
+			id: I64_PLACEHOLDER_WHICH_DOES_NOT_MATTER,
+			account: github::User {
+				login: owner.login.clone(),
+				type_field: Some(github::UserType::Bot),
+			},
+		}])),
+	);
+	github_api.expect(
+		Expectation::matching(request::method_path(
+			"POST",
+			format!(
+				"/app/installations/{}/access_tokens",
+				I64_PLACEHOLDER_WHICH_DOES_NOT_MATTER
+			),
+		))
+		.times(0..)
+		.respond_with(json_encoded(github::InstallationToken {
+			token: "does not matter".to_string(),
+			expires_at: None,
+		})),
+	);
+
+	github_api.expect(
+		Expectation::matching(request::method_path(
+			"GET",
+			format!(
+				"/repos/{}/{}/contents/{}",
+				&owner.login,
+				repo,
+				parity_processbot::constants::PROCESS_FILE
+			),
+		))
+		.times(0..)
+		.respond_with(|| status_code(200).body(base64::encode("[]"))),
+	);
+
+	github_api.expect(
+		Expectation::matching(request::method_path(
+			"GET",
+			format!("/orgs/{}/members/{}", &owner.login, &owner.login),
+		))
+		.times(0..)
+		.respond_with(
+			status_code(204)
+				.append_header("Content-Type", "application/json")
+				.body(serde_json::to_string(&json!({})).unwrap()),
+		),
+	);
+
+	let mut next_team_id = 0;
+	for team in &[
+		parity_processbot::constants::CORE_DEVS_GROUP,
+		parity_processbot::constants::SUBSTRATE_TEAM_LEADS_GROUP,
+	] {
+		next_team_id += 1;
+		setup_team(
+			&github_api,
+			&owner.login,
+			team,
+			next_team_id,
+			vec![owner.clone()],
+		);
+	}
+
+	let git_daemon_port = get_available_port().unwrap();
+	let git_daemon_handle = Command::new("git")
+		.arg("daemon")
+		.arg(format!("--port={}", git_daemon_port))
+		.arg(format!("--base-path={}", git_daemon_dir_path_str))
+		.arg("--export-all")
+		.arg("--enable=receive-pack")
+		.stdout(Stdio::null())
+		.current_dir((&git_daemon_dir).path())
+		.spawn()
+		.unwrap();
+
+	CommonSetupOutput {
+		log_dir,
+		git_daemon_handle,
+		git_daemon_dir,
+		github_api,
+		github_api_url,
+		db_dir,
+		repo_dir,
+		github_app_id: USIZE_PLACEHOLDER_WHICH_DOES_NOT_MATTER,
+		owner,
+		repo_name: repo,
+		repo_full_name,
+		private_key,
+		next_team_id,
+	}
+}
+
+pub fn setup_team(
+	github_api: &Server,
+	org: &str,
+	team: &str,
+	team_id: i64,
+	users: Vec<github::User>,
+) {
+	github_api.expect(
+		Expectation::matching(request::method_path(
+			"GET",
+			format!("/orgs/{}/teams/{}", org, team),
+		))
+		.times(0..)
+		.respond_with(json_encoded(github::Team { id: team_id })),
+	);
+
+	github_api.expect(
+		Expectation::matching(request::method_path(
+			"GET",
+			format!("/teams/{}/members", team_id),
+		))
+		.times(0..)
+		.respond_with(json_encoded(users)),
+	);
+}
+
+pub fn setup_commit(setup: &CommonSetupOutput, sha: &str) {
+	let CommonSetupOutput {
+		owner,
+		repo_name,
+		github_api,
+		..
+	} = setup;
+
+	github_api.expect(
+		Expectation::matching(request::method_path(
+			"GET",
+			format!(
+				"/repos/{}/{}/commits/{}/status",
+				&owner.login, repo_name, sha
+			),
+		))
+		.times(0..)
+		.respond_with(json_encoded(github::CombinedStatus {
+			statuses: vec![github::Status {
+				id: 1,
+				context: "does not matter".to_string(),
+				description: Some("does not matter".to_string()),
+				state: github::StatusState::Success,
+			}],
+		})),
+	);
+
+	github_api.expect(
+		Expectation::matching(request::method_path(
+			"GET",
+			format!(
+				"/repos/{}/{}/commits/{}/check-runs",
+				&owner.login, repo_name, sha
+			),
+		))
+		.times(0..)
+		.respond_with(json_encoded(github::CheckRuns {
+			check_runs: vec![github::CheckRun {
+				id: 1,
+				name: "does not matter".to_string(),
+				status: github::CheckRunStatus::Completed,
+				conclusion: Some(github::CheckRunConclusion::Success),
+				head_sha: sha.to_string(),
+			}],
+		})),
+	);
+}
+
+pub struct SetupPullRequestOutput {
+	pub url: String,
+	pub html_url: String,
+	pub number: i64,
+}
+pub fn setup_pull_request(
+	setup: &CommonSetupOutput,
+	repo: &github::Repository,
+	head_sha: &str,
+	branch: &str,
+	number: i64,
+) -> SetupPullRequestOutput {
+	let CommonSetupOutput {
+		github_api,
+		github_api_url,
+		owner,
+		repo_dir,
+		..
+	} = setup;
+
+	let pr_api_path = &format!("/repos/{}/pulls/{}", &repo.full_name, number);
+	let issue_api_path =
+		&format!("/repos/{}/issues/{}", &repo.full_name, number);
+	let url = format!(
+		"{}/repos/{}/pulls/{}",
+		github_api_url, &repo.full_name, number
+	);
+	let html_url = format!("{}/pull/{}", &repo.html_url, number);
+
+	{
+		let repo_dir: &'static PathBuf =
+			&*Box::leak(Box::new(repo_dir.clone()));
+		let branch: &'static String = &*Box::leak(Box::new(branch.to_string()));
+		let owner_branch: &'static String =
+			&*Box::leak(Box::new(branch.to_string()));
+		github_api.expect(
+			Expectation::matching(request::method_path(
+				"PUT",
+				format!("{}/merge", pr_api_path),
+			))
+			.times(0..)
+			.respond_with(move || {
+				exec(
+					"git",
+					&["checkout", branch],
+					Some(repo_dir),
+					Some(CmdConfiguration::SilentStderrStartingWith(&[
+						"Switched to branch",
+					])),
+				);
+				let tmp_branch_name = "tmp";
+				exec(
+					"git",
+					&["checkout", "-b", tmp_branch_name],
+					Some(repo_dir),
+					Some(CmdConfiguration::SilentStderrStartingWith(&[
+						"Switched to a new branch",
+					])),
+				);
+				let merge_output = get_cmd_output(
+					"git",
+					&["merge", owner_branch],
+					Some(repo_dir),
+				);
+				// Merge is only successful if contributor branch is up-to-date with master; otherwise,
+				// simulates the "Pull Request is not mergeable" response (code 405).
+				// https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request
+				let result = if merge_output == "Already up to date." {
+					status_code(200)
+						.append_header("Content-Type", "application/json")
+						.body(serde_json::to_string(&json!({})).unwrap())
+				} else {
+					status_code(405)
+						.append_header("Content-Type", "application/json")
+						.body(
+							serde_json::to_string(
+								&json!({ "message": "Pull Request is not mergeable" }),
+							)
+							.unwrap(),
+						)
+				};
+				exec(
+					"git",
+					&["merge", "--abort"],
+					Some(repo_dir),
+					Some(CmdConfiguration::SilentStderrStartingWith(&[
+						"fatal: There is no merge to abort",
+					])),
+				);
+				exec(
+					"git",
+					&["checkout", owner_branch],
+					Some(repo_dir),
+					Some(CmdConfiguration::SilentStderrStartingWith(&[
+						"Switched to branch",
+					])),
+				);
+				exec(
+					"git",
+					&["branch", "-D", tmp_branch_name],
+					Some(repo_dir),
+					None,
+				);
+				result
+			}),
+		);
+	}
+
+	github_api.expect(
+		Expectation::matching(request::method_path(
+			"GET",
+			pr_api_path.to_string(),
+		))
+		.times(0..)
+		.respond_with(json_encoded(github::PullRequest {
+			body: None,
+			number,
+			mergeable: Some(true),
+			html_url: html_url.clone(),
+			url: url.clone(),
+			user: Some(owner.clone()),
+			base: github::Base {
+				ref_field: branch.to_string(),
+				repo: github::BaseRepo {
+					name: repo.name.clone(),
+					owner: owner.clone(),
+				},
+			},
+			head: github::Head {
+				ref_field: branch.to_string(),
+				sha: head_sha.to_string(),
+				repo: github::HeadRepo {
+					name: repo.name.clone(),
+					owner: owner.clone(),
+				},
+			},
+			merged: false,
+			maintainer_can_modify: true,
+		})),
+	);
+
+	github_api.expect(
+		Expectation::matching(request::method_path(
+			"GET",
+			format!("{}/reviews", pr_api_path),
+		))
+		.times(0..)
+		.respond_with(json_encoded(vec![github::Review {
+			id: 1,
+			user: Some(owner.clone()),
+			state: Some(github::ReviewState::Approved),
+		}])),
+	);
+
+	github_api.expect(
+		Expectation::matching(request::method_path(
+			"POST",
+			format!("{}/comments", issue_api_path,),
+		))
+		.times(0..)
+		.respond_with(
+			status_code(201)
+				.append_header("Content-Type", "application/json")
+				.body(serde_json::to_string(&json!({})).unwrap()),
+		),
+	);
+
+	SetupPullRequestOutput {
+		url,
+		html_url,
+		number,
+	}
+}

--- a/tests/merge.rs
+++ b/tests/merge.rs
@@ -1,0 +1,121 @@
+use insta::assert_snapshot;
+use parity_processbot::{
+	config::MainConfig,
+	github,
+	github_bot::GithubBot,
+	webhook::{handle_payload, AppState},
+	PlaceholderDeserializationItem,
+};
+use rocksdb::DB;
+use std::fs;
+
+mod helpers;
+
+use helpers::{cmd::*, constants::*, read_snapshot, setup::*};
+
+#[tokio::test]
+async fn simple_merge_succeeds() {
+	let common_setup = common_setup();
+	let CommonSetupOutput {
+		log_dir,
+		github_api_url,
+		db_dir,
+		owner,
+		repo_dir,
+		private_key,
+		github_app_id,
+		repo_name,
+		repo_full_name,
+		..
+	} = &common_setup;
+
+	// Create PR branch
+	let pr_branch = "contributor_patches";
+	exec(
+		"git",
+		&["checkout", "-b", pr_branch],
+		Some(repo_dir),
+		Some(CmdConfiguration::SilentStderrStartingWith(&[
+			"Switched to a new branch",
+		])),
+	);
+
+	// Add a commit to the PR's branch
+	fs::write(repo_dir.join("foo"), "this file has changed").unwrap();
+	exec("git", &["add", "."], Some(repo_dir), None);
+	exec(
+		"git",
+		&["commit", "-m", "change file"],
+		Some(repo_dir),
+		None,
+	);
+	let pr_head_sha =
+		get_cmd_output("git", &["rev-parse", "HEAD"], Some(&repo_dir));
+
+	// Setup the commit in the API so that the status checks criterion will pass
+	setup_commit(&common_setup, &pr_head_sha);
+
+	let repo = github::Repository {
+		name: repo_name.to_string(),
+		full_name: repo_full_name.clone(),
+		owner: owner.clone(),
+		html_url: format!(
+			"{}/{}",
+			URL_PLACEHOLDER_WHICH_DOES_NOT_MATTER, repo_full_name
+		),
+	};
+
+	let mut next_pr_number: i64 = 0;
+	next_pr_number += 1;
+	let pr = &setup_pull_request(
+		&common_setup,
+		&repo,
+		&pr_head_sha,
+		pr_branch,
+		next_pr_number,
+	);
+
+	let config = MainConfig {
+		installation_login: owner.login.clone(),
+		webhook_secret: "".to_owned(),
+		webhook_port: "".to_string(),
+		db_path: db_dir.path().display().to_string(),
+		private_key: private_key.clone(),
+		webhook_proxy_url: None,
+		disable_org_check: false,
+		github_api_url: github_api_url.clone(),
+		github_app_id: *github_app_id,
+		merge_command_delay: 0,
+		companion_status_settle_delay: 0,
+	};
+	let github_bot = GithubBot::new(&config);
+	let db = DB::open_default(&config.db_path).unwrap();
+	let state = AppState {
+		db,
+		github_bot,
+		config,
+	};
+
+	let _ = handle_payload(
+		github::Payload::IssueComment {
+			action: github::IssueCommentAction::Created,
+			comment: github::Comment {
+				body: "bot merge".to_string(),
+				user: Some(owner.clone()),
+			},
+			issue: github::WebhookIssueComment {
+				number: pr.number,
+				html_url: pr.html_url.clone(),
+				repository_url: repo.html_url.clone(),
+				pull_request: Some(PlaceholderDeserializationItem {}),
+			},
+		},
+		&state,
+	)
+	.await;
+
+	assert_snapshot!(read_snapshot(
+		log_dir.path().to_path_buf(),
+		&[&pr_head_sha]
+	));
+}

--- a/tests/snapshots/merge__simple_merge_succeeds.snap
+++ b/tests/snapshots/merge__simple_merge_succeeds.snap
@@ -1,0 +1,18 @@
+---
+source: tests/merge.rs
+expression: "read_snapshot(log_dir.path().to_path_buf(), &[&pr_head_sha])"
+
+---
+INFO [parity_processbot::webhook] Merge(Normal) requested by owner in https://localhost/owner/repo/pull/1
+INFO [parity_processbot::webhook] https://localhost/owner/repo/pull/1 is mergeable
+INFO [parity_processbot::webhook] https://localhost/owner/repo/pull/1 merge requested by a team lead.
+INFO [parity_processbot::webhook] https://localhost/owner/repo/pull/1 statuses: CombinedStatus { statuses: [Status { id: 1, context: "does not matter", state: Success, description: Some("does not matter") }] }
+INFO [parity_processbot::webhook] https://localhost/owner/repo/pull/1 latest_statuses: {"does not matter": (1, Success)}
+INFO [parity_processbot::webhook] https://localhost/owner/repo/pull/1 has success status
+INFO [parity_processbot::webhook] https://localhost/owner/repo/pull/1 checks: CheckRuns { check_runs: [CheckRun { id: 1, name: "does not matter", status: Completed, conclusion: Some(Success), head_sha: "{REDACTED}" }] }
+INFO [parity_processbot::webhook] https://localhost/owner/repo/pull/1 latest_checks,: {"does not matter": (1, Completed, Some(Success))}
+INFO [parity_processbot::webhook] https://localhost/owner/repo/pull/1 has successful checks
+INFO [parity_processbot::webhook] https://localhost/owner/repo/pull/1 merged successfully.
+INFO [parity_processbot::webhook] Merging companions of https://localhost/owner/repo/pull/1
+INFO [parity_processbot::companion] Checking for companions in https://localhost/owner/repo/pull/1
+


### PR DESCRIPTION
Adds an integration test and runs it on CI.

This PR includes a single simple integration test because its main purpose is to introduce the ability to running integration tests in the first place, since we don't have any. In the future, more integration tests can be added upon the code introduced here.

The [original branch](https://github.com/paritytech/parity-processbot/tree/prev-integration-tests) contained a new feature which I've not included here to reduce the scope of this PR and also due to time constraints.