### PR TITLE
Avoid package ambiguity during companion updates by specifying versions

### DIFF
--- a/src/companion.rs
+++ b/src/companion.rs
@@ -221,11 +221,11 @@ async fn update_companion_repository(
 				),
 			}
 		})?;
-	let pkgs_in_companion: HashSet<&str> = {
+	let pkgs_in_companion: HashSet<String> = {
 		HashSet::from_iter(lockfile.packages.iter().filter_map(|pkg| {
 			if let Some(src) = pkg.source.as_ref() {
 				if src.url().as_str() == url_merge_was_done_in {
-					Some(pkg.name.as_str())
+					Some(format!("{}:{}", pkg.name.as_str(), pkg.version))
 				} else {
 					None
 				}


### PR DESCRIPTION
Sometimes a repository might have two packages with the same name, as shown in https://github.com/paritytech/cumulus/pull/693#issuecomment-949601205, so it's relevant to qualify them by their version to hopefully get rid of the ambiguity