### PR TITLE
Restrict regular expression for detecting companions

### DIFF
--- a/src/companion.rs
+++ b/src/companion.rs
@@ -17,7 +17,7 @@ use crate::{
 		wait_to_merge, AppState, MergeRequest,
 	},
 	MergeAllowedOutcome, Result, COMPANION_LONG_REGEX, COMPANION_PREFIX_REGEX,
-	COMPANION_SHORT_REGEX, PR_HTML_URL_REGEX,
+	COMPANION_SHORT_REGEX, OWNER_AND_REPO_SEQUENCE, PR_HTML_URL_REGEX,
 };
 
 async fn update_companion_repository(
@@ -804,6 +804,22 @@ mod tests {
 			parse_all_companions(
 				&[(owner.to_owned(), repo.to_owned())],
 				&companion_description
+			),
+			vec![]
+		);
+	}
+
+	#[test]
+	fn test_restricted_regex() {
+		let owner = "paritytech";
+		let repo = "polkadot";
+		let pr_number = 1234;
+		let companion_url = format!("{}/{}#{}", owner, repo, pr_number);
+		assert_eq!(
+			parse_all_companions(
+				&[],
+				// the companion expression should not be matched because of the " for" part
+				&format!("companion for {}", &companion_url)
 			),
 			vec![]
 		);

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,7 +1,7 @@
 use crate::{
 	companion::parse_all_companions, error::*,
 	utils::parse_bot_comment_from_text, webhook::MergeRequestBase,
-	PlaceholderDeserializationItem, PR_HTML_URL_REGEX,
+	PlaceholderDeserializationItem, OWNER_AND_REPO_SEQUENCE, PR_HTML_URL_REGEX,
 };
 use regex::Regex;
 use serde::{Deserialize, Serialize};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,8 +1,19 @@
 #[macro_export]
+macro_rules! OWNER_AND_REPO_SEQUENCE {
+	() => {
+		r"(?P<owner>[^ \t\n]+)/(?P<repo>[^ \t\n]+)"
+	};
+}
+
+#[macro_export]
 macro_rules! PR_HTML_URL_REGEX {
-    () => {
-        r"(?P<html_url>https://[^/\n]+/(?P<owner>[^/\n]+)/(?P<repo>[^/\n]+)/pull/(?P<number>[[:digit:]]+))"
-    };
+	() => {
+		concat!(
+			r"(?P<html_url>https://[^ \t\n]+/",
+			OWNER_AND_REPO_SEQUENCE!(),
+			r"/pull/(?P<number>[[:digit:]]+))"
+		)
+	};
 }
 
 #[macro_export]
@@ -24,7 +35,8 @@ macro_rules! COMPANION_SHORT_REGEX {
 	() => {
 		concat!(
 			COMPANION_PREFIX_REGEX!(),
-			r"(?P<owner>[^/\n]+)/(?P<repo>[^/\n]+)#(?P<number>[[:digit:]]+)"
+			OWNER_AND_REPO_SEQUENCE!(),
+			r"#(?P<number>[[:digit:]]+)"
 		)
 	};
 }


### PR DESCRIPTION
Problem: Current `[^/\n]+` expression for detecting parts of companion lines is too loose, e.g. it broke for https://github.com/paritytech/cumulus/pull/870#issue-1084759761.

Solution: restrict the regular expression, add tests

closes #349 

closes #345