### PR TITLE
Improve error message for pr-custom-review

### DIFF
--- a/src/companion.rs
+++ b/src/companion.rs
@@ -522,15 +522,17 @@ pub async fn check_all_companions_are_mergeable(
 		)
 		.await?
 		.1;
+
+		const CHECK_REVIEWS_STATUS: &str = "Check reviews";
 		let reviews_are_passing = latest_statuses
-			.get("Check reviews")
+			.get(CHECK_REVIEWS_STATUS)
 			.map(|(_, state, _)| state == &StatusState::Success)
 			.unwrap_or(false);
 		if !reviews_are_passing {
 			return Err(Error::Message {
 				msg: format!(
-					"pr-custom-review is not passing for {}",
-					&companion.html_url
+					"\"{}\" status is not passing for {}",
+					CHECK_REVIEWS_STATUS, &companion.html_url
 				),
 			});
 		}


### PR DESCRIPTION
`"pr-custom-review is not passing"` might be confusing to those who don't understand what status pr-custom-review generates. It's better to be more explicit and direct about which status is being considered for the error message.