### PR TITLE
Add CI job to publish docker image description to hub.docker.com

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,6 +135,23 @@ docker-build-push:
   tags:
     - kubernetes-parity-build
 
+publish-docker-image-description:
+  stage:                           dockerize
+  variables:
+    CI_IMAGE:                      paritytech/dockerhub-description
+    DOCKERHUB_REPOSITORY:          ${CI_REGISTRY}/${KUBE_NAMESPACE}
+    DOCKER_USERNAME:               $Docker_Hub_User_Parity
+    DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
+    README_FILEPATH:               $CI_PROJECT_DIR/Dockerfile.README.md
+    SHORT_DESCRIPTION:             "parity-processbot is a GitHub App which drives the Companion Build System's merge process"
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "master"
+      changes:
+      - Dockerfile.README.md
+  script:
+    - cd / && sh entrypoint.sh
+  tags:
+    - kubernetes-parity-build
 
 #### stage:                        deploy
 

--- a/Dockerfile.README.md
+++ b/Dockerfile.README.md
@@ -1,0 +1,5 @@
+# parity-processbot
+
+parity-processbot is a GitHub App which drives the Companion Build System's merge process
+
+### [GitHub](https://github.com/paritytech/parity-processbot)


### PR DESCRIPTION
Added CI job to publish Docker image description to [hub.docker.com](https://hub.docker.com/r/paritytech/processbot)
Description can be updated in a `Dockerfile.README.md` file in a repository root and as soon it will be merged into the `master` branch, its content will get published to [hub.docker.com](https://hub.docker.com/r/paritytech/processbot)

Related https://github.com/paritytech/ci_cd/issues/741