### PR TITLE
Move CI_IMAGE to external snippet via !reference

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,14 @@
+include:
+  - project: parity/infrastructure/ci_cd/shared
+    ref: main
+    file: /common/ci-unified.yml
+
 variables:
   KUBE_NAMESPACE:                  "processbot"
   CI_REGISTRY:                     "paritytech"
   BUILDAH_IMAGE:                   "quay.io/buildah/stable:v1.29"
   BUILDAH_COMMAND:                 "buildah --storage-driver overlay2"
-  CI_IMAGE:                        "paritytech/ci-linux@sha256:0fe9d110a29ec77ac6fa6507e4af968ea6aced6f6b7ce4deb231696ffc19b715" # 1.70.0-bullseye 2023-06-20
+  CI_IMAGE:                        !reference [.ci-unified, variables, CI_IMAGE]
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       3
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"


### PR DESCRIPTION
As CI migrated to new ci-unified image, it's decided to move`CI_IMAGE` tag variable to dedicated snippet [parity/infrastructure/ci_cd/shared/comon/ci-unified.yml](https://gitlab.parity.io/parity/infrastructure/ci_cd/shared/-/blob/main/common/ci-unified.yml) and use it via include/!reference in jobs. 

For custom rust toolchain versions see [ci-unified readme](https://github.com/paritytech/scripts/blob/master/dockerfiles/ci-unified/README.md)
 
Relates to [Finish and settle down on the ci-unified image #821](https://github.com/paritytech/ci_cd/issues/821#issuecomment-1643745148)

also see [this comment](https://github.com/paritytech/ci_cd/issues/693#issuecomment-1342434913) 